### PR TITLE
add exp_separator, SOI and EOI pest rules.

### DIFF
--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -86,5 +86,5 @@ hash    = { "0x" ~ (ASCII_HEX_DIGIT){64} }
 ens     = { (ASCII_ALPHANUMERIC)+ ~ ".eth" }
 
 // Helpers
-WHITESPACE = _{ " " | "\t" | NEWLINE}
+WHITESPACE = _{ " " | "\t" | NEWLINE }
 

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -1,4 +1,4 @@
-program = _{SOI ~ (get){1, } ~ eoi}
+program = _{SOI ~ (get){1, } ~ silent_eoi}
 
 get       = {
     "GET" ~ WHITESPACE* ~ fields* ~ WHITESPACE* ~ "FROM" ~ WHITESPACE* ~ entity ~ WHITESPACE* ~ entity_id ~ WHITESPACE* ~ "ON" ~ WHITESPACE* ~ chain ~ exp_separator* ~ WHITESPACE*
@@ -6,8 +6,6 @@ get       = {
 fields    = { (account_field_list | block_field_list | tx_field_list) }
 entity    = { "account" | "block" | "tx" }
 entity_id = { hash | account_id | integer }
-exp_separator = _{"," | ";"}
-eoi = _{ !ANY } //silent EOI
 
 // Account
 account_field_list = _{ account_field ~ (", " ~ account_field)* }
@@ -86,4 +84,6 @@ ens = { (ASCII_ALPHANUMERIC)+ ~ ".eth" }
 
 // Helpers
 WHITESPACE = _{ " " | "\t" | NEWLINE }
+exp_separator = _{"," | ";"}
+silent_eoi = _{ !ANY }
 

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -1,11 +1,12 @@
-program = _{ (get){1, } }
+program = _{SOI ~ (get){1, } ~ EOI}
 
 get       = {
-    "GET" ~ WHITESPACE* ~ fields* ~ WHITESPACE* ~ "FROM" ~ WHITESPACE* ~ entity ~ WHITESPACE* ~ entity_id ~ WHITESPACE* ~ "ON" ~ WHITESPACE* ~ chain
+    "GET" ~ WHITESPACE* ~ fields* ~ WHITESPACE* ~ "FROM" ~ WHITESPACE* ~ entity ~ WHITESPACE* ~ entity_id ~ WHITESPACE* ~ "ON" ~ WHITESPACE* ~ chain ~ exp_separator* ~ WHITESPACE*
 }
 fields    = { (account_field_list | block_field_list | tx_field_list) }
 entity    = { "account" | "block" | "tx" }
 entity_id = { hash | account_id | integer }
+exp_separator = _{"," | ";"}
 
 // Account
 account_field_list = _{ account_field ~ (", " ~ account_field)* }
@@ -84,5 +85,5 @@ hash    = { "0x" ~ (ASCII_HEX_DIGIT){64} }
 ens     = { (ASCII_ALPHANUMERIC)+ ~ ".eth" }
 
 // Helpers
-WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
+WHITESPACE = _{ " " | "\t" | NEWLINE}
 

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -1,4 +1,4 @@
-program = _{SOI ~ (get){1, } ~ EOI}
+program = _{SOI ~ (get){1, } ~ eoi}
 
 get       = {
     "GET" ~ WHITESPACE* ~ fields* ~ WHITESPACE* ~ "FROM" ~ WHITESPACE* ~ entity ~ WHITESPACE* ~ entity_id ~ WHITESPACE* ~ "ON" ~ WHITESPACE* ~ chain ~ exp_separator* ~ WHITESPACE*
@@ -7,6 +7,7 @@ fields    = { (account_field_list | block_field_list | tx_field_list) }
 entity    = { "account" | "block" | "tx" }
 entity_id = { hash | account_id | integer }
 exp_separator = _{"," | ";"}
+eoi = _{ !ANY } //silent EOI
 
 // Account
 account_field_list = _{ account_field ~ (", " ~ account_field)* }


### PR DESCRIPTION
# Summary

- Add SOI and EOI pest expressions to the `.pest` file. This will force the file to have only valid EQL expression as defined by the parser.
- Add `exp_separators` ignored entities to the pest rules so the user can choose to use or not use them or even make inline multiple EQL expressions.
  - Example: `GET timestamp FROM block 1 ON ETH, GET timestamp FROM block 2 ON ETH`

## Associated issue
https://github.com/iankressin/eql/issues/25#issue-2456454195