### PR TITLE
Improve error readbility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /target
-.eql
+**.eql

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-**.eql

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.eql

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -75,9 +75,15 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         SubCommand::Run(run_args) => {
             let source = std::fs::read_to_string(run_args.file)?;
             let result_handler = ResultHandler::new();
-            let result = Interpreter::run_program(&source).await?;
-
-            result_handler.handle_result(result);
+            let result = Interpreter::run_program(&source).await;
+            match result {
+                Ok(query_results) => {
+                    result_handler.handle_result(query_results);
+                }
+                Err(e) => {
+                    eprintln!("{}", e);
+                }
+            }
         }
         SubCommand::Repl => {
             Repl::new().run().await?;


### PR DESCRIPTION
# Summary

- Add an error print (`eprintln`!) in the CLI main.rs file to improve the readability of the EQL expressions errors.

## Associated issue
https://github.com/iankressin/eql/issues/27#issue-2456537429