### PR TITLE
Add logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "eql_core"
-version = "0.1.8"
+version = "0.1.10"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "alloy-network",
  "alloy-provider",
  "alloy-rpc-client",
+ "alloy-rpc-types",
  "alloy-serde",
  "alloy-transport",
  "alloy-transport-http",
@@ -292,6 +293,17 @@ dependencies = [
  "tower",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5d76f1e8b22f48b7b8f985782b68e7eb3938780e50e8b646a53e41a598cdf5"
+dependencies = [
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -64,7 +64,7 @@ impl ResultHandler {
                 }
                 ExpressionResult::Log(query_res) => {
                     println!("> {}", query_result.query);
-                    let mut table = Table::new(query_res);
+                    let mut table = Table::new(vec![query_res]);
                     table.with(Style::rounded());
                     println!("{}\n", table.to_string());
                 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -60,10 +60,7 @@ impl ResultHandler {
                     println!("{}", to_table(vec![query_res])?);
                 }
                 ExpressionResult::Log(query_res) => {
-                    println!("> {}", query_result.query);
-                    let mut table = Table::new(vec![query_res]);
-                    table.with(Style::rounded());
-                    println!("{}\n", table.to_string());
+                    println!("{}", to_table(query_res)?);
                 }
             }
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -62,6 +62,12 @@ impl ResultHandler {
                     table.with(Style::rounded());
                     println!("{}\n", table.to_string());
                 }
+                ExpressionResult::Log(query_res) => {
+                    println!("> {}", query_result.query);
+                    let mut table = Table::new(query_res);
+                    table.with(Style::rounded());
+                    println!("{}\n", table.to_string());
+                }
             }
         }
     }

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -240,10 +240,9 @@ impl Repl {
                     });
                 }
                 ExpressionResult::Log(query_res) => {
-                    let mut table = Table::new(vec![query_res]);
-                    table.with(Style::rounded());
+                    let table = to_table(query_res)?;
                     table.to_string().split("\n").for_each(|line| {
-                        queue!(stdout(), MoveToNextLine(1), Print(line.green())).unwrap();
+                        queue!(stdout(), MoveToNextLine(1), Print(line.cyan())).unwrap();
                     });
                 }
             }

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -235,6 +235,13 @@ impl Repl {
                         queue!(stdout(), MoveToNextLine(1), Print(line.yellow())).unwrap();
                     });
                 }
+                ExpressionResult::Log(query_res) => {
+                    let mut table = Table::new(vec![query_res]);
+                    table.with(Style::rounded());
+                    table.to_string().split("\n").for_each(|line| {
+                        queue!(stdout(), MoveToNextLine(1), Print(line.green())).unwrap();
+                    });
+                }
             }
         }
     }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/iankressin/eql"
 readme = "README.md"
 
 [dependencies]
-alloy = { version = "0.2", features = ["std", "contract", "provider-http", "network"] }
+alloy = { version = "0.2", features = ["std", "contract", "provider-http", "network", "rpc-types"] }
 pest = "2.7.10"
 pest_derive = "2.6"
 tabled = "0.15.0"

--- a/crates/core/src/common/entity.rs
+++ b/crates/core/src/common/entity.rs
@@ -7,6 +7,7 @@ pub enum Entity {
     Block,
     Transaction,
     Account,
+    Log,
 }
 
 impl Display for Entity {
@@ -15,6 +16,7 @@ impl Display for Entity {
             Entity::Block => write!(f, "block"),
             Entity::Transaction => write!(f, "transaction"),
             Entity::Account => write!(f, "account"),
+            Entity::Log => write!(f, "log"),
         }
     }
 }
@@ -33,6 +35,7 @@ impl TryFrom<&str> for Entity {
             "block" => Ok(Entity::Block),
             "tx" => Ok(Entity::Transaction),
             "account" => Ok(Entity::Account),
+            "log" => Ok(Entity::Log),
             invalid_entity => Err(EntityError::InvalidEntity(invalid_entity.to_string())),
         }
     }

--- a/crates/core/src/common/entity_filter.rs
+++ b/crates/core/src/common/entity_filter.rs
@@ -1,0 +1,84 @@
+use alloy::{
+    eips::BlockNumberOrTag,
+    rpc::types::Filter,
+};
+use std::error::Error;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EntityFilter {
+    Block(BlockRange),
+    Log(BlockRange),
+    Transaction(),
+    Account(),
+
+}
+
+// TODO: return instance of Error trait instead of &'static str
+impl TryFrom<&str> for EntityFilter {
+    type Error = Box<dyn Error>;
+
+    fn try_from(id: &str) -> Result<Self, Self::Error> {
+        let (start, end) = match id.split_once(":") {
+            Some((start, end)) => {
+                let start = parse_block_number_or_tag(start)?;
+                let end = parse_block_number_or_tag(end)?;
+                (start, Some(end))
+            }
+            None => parse_block_number_or_tag(id).map(|start| (start, None))?,
+        };
+
+        Ok(EntityFilter::Block(BlockRange { start, end }))
+    }
+}
+
+impl EntityFilter {
+    pub fn to_block_range(
+        &self,
+    ) -> Result<(BlockNumberOrTag, Option<BlockNumberOrTag>), EntityFilterError> {
+        match self {
+            EntityFilter::Block(block_id) => Ok((block_id.start.clone(), block_id.end.clone())),
+            _ => Err(EntityFilterError::InvalidBlockNumber),
+        }
+    }
+
+    pub fn to_filter(&self) -> Result<Filter, EntityFilterError> {
+        match self {
+            EntityFilter::Log(block_id) => {
+                let mut filter = Filter::new().from_block(block_id.start);
+                if let Some(end) = block_id.end {
+                    filter = filter.to_block(end);
+                }
+                Ok(filter)
+            }
+            _ => Err(EntityFilterError::InvalidBlockNumber),
+        }
+    }
+}
+
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct BlockRange {
+    start: BlockNumberOrTag,
+    end: Option<BlockNumberOrTag>,
+}
+
+impl BlockRange {
+    pub fn new(start: BlockNumberOrTag, end: Option<BlockNumberOrTag>) -> Self {
+        Self { start, end }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum EntityFilterError {
+    #[error("Invalid block number")]
+    InvalidBlockNumber,
+}
+
+fn parse_block_number_or_tag(id: &str) -> Result<BlockNumberOrTag, EntityFilterError> {
+    match id.parse::<u64>() {
+        Ok(id) => Ok(BlockNumberOrTag::Number(id)),
+        Err(_) => id
+            .parse::<BlockNumberOrTag>()
+            .map_err(|_| EntityFilterError::InvalidBlockNumber),
+    }
+}

--- a/crates/core/src/common/entity_filter.rs
+++ b/crates/core/src/common/entity_filter.rs
@@ -91,22 +91,30 @@ impl EntityFilter {
         }
     }
 
-    pub fn to_filter(&self, mut filter: Filter) -> Result<Filter, EntityFilterError> {
+    fn to_filter(&self, filter: Filter) -> Filter {
         match self {
             EntityFilter::LogBlockRange(range) => {
-                filter = filter.from_block(range.start);
-                filter = filter.to_block(range.end.unwrap_or(range.start)); // If end is None, range is actually one block. unwrap_or will reuse start as range end.
-            }
-            EntityFilter::LogBlockHash(hash) => filter = filter.at_block_hash(*hash),
-            EntityFilter::LogEmitterAddress(address) => filter = filter.address(*address),
-            EntityFilter::LogEventSignature(signature) => filter = filter.event(signature),
-            EntityFilter::LogTopic0(topic_hash) => filter = filter.event_signature(*topic_hash),
-            EntityFilter::LogTopic1(topic_hash) => filter = filter.topic1(*topic_hash),
-            EntityFilter::LogTopic2(topic_hash) => filter = filter.topic2(*topic_hash),
-            EntityFilter::LogTopic3(topic_hash) => filter = filter.topic3(*topic_hash),
+                filter.from_block(range.start)
+                    // If end is None, range is actually one block. unwrap_or will reuse start as range  
+                    .to_block(range.end.unwrap_or(range.start))
+            },
+            EntityFilter::LogBlockHash(hash) => filter.at_block_hash(*hash),
+            EntityFilter::LogEmitterAddress(address) => filter.address(*address),
+            EntityFilter::LogEventSignature(signature) => filter.event(signature),
+            EntityFilter::LogTopic0(topic_hash) => filter.event_signature(*topic_hash),
+            EntityFilter::LogTopic1(topic_hash) => filter.topic1(*topic_hash),
+            EntityFilter::LogTopic2(topic_hash) => filter.topic2(*topic_hash),
+            EntityFilter::LogTopic3(topic_hash) => filter.topic3(*topic_hash),
         }
-    
-        Ok(filter)
+
+    }
+
+    pub fn build_filter(entity_filters: &[EntityFilter]) -> Filter {
+        entity_filters
+            .iter()
+            .fold(Filter::new(), |filter, entity_filter| {
+                entity_filter.to_filter(filter)
+            })
     }
 }
 

--- a/crates/core/src/common/entity_filter.rs
+++ b/crates/core/src/common/entity_filter.rs
@@ -63,8 +63,8 @@ impl EntityFilter {
         match self {
             EntityFilter::LogBlockRange(block_id) => {
                 filter = filter.from_block(block_id.start);
-                if let Some(end) = block_id.end {
-                    filter = filter.to_block(end);
+                if block_id.end == None {
+                    filter = filter.to_block(block_id.start);
                 }
                 Ok(filter)
             }

--- a/crates/core/src/common/entity_filter.rs
+++ b/crates/core/src/common/entity_filter.rs
@@ -77,11 +77,11 @@ impl EntityFilter {
     }
 }
 
-
+//I should provide methods to change start and end instead of making the params pub.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct BlockRange {
-    start: BlockNumberOrTag,
-    end: Option<BlockNumberOrTag>,
+    pub start: BlockNumberOrTag,
+    pub end: Option<BlockNumberOrTag>,
 }
 
 impl BlockRange {

--- a/crates/core/src/common/entity_filter.rs
+++ b/crates/core/src/common/entity_filter.rs
@@ -8,6 +8,12 @@ use pest::iterators::Pair;
 use crate::interpreter::frontend::parser::{ParserError, Rule};
 use super::entity_id::parse_block_number_or_tag;
 
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum EntityFilterError {
+    #[error("Invalid block number")]
+    InvalidBlockNumber,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum EntityFilter {
     LogBlockRange(BlockRange),
@@ -132,10 +138,4 @@ impl BlockRange {
     pub fn range(&self) -> (BlockNumberOrTag, Option<BlockNumberOrTag>) {
         (self.start, self.end)
     }
-}
-
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-pub enum EntityFilterError {
-    #[error("Invalid block number")]
-    InvalidBlockNumber,
 }

--- a/crates/core/src/common/entity_filter.rs
+++ b/crates/core/src/common/entity_filter.rs
@@ -52,6 +52,10 @@ impl<'a> TryFrom<Pair<'a, Rule>> for EntityFilter {
                 let hash = hash.parse::<B256>()?;
                 Ok(EntityFilter::LogBlockHash(hash))
             }
+            Rule::event_signature_filter => {
+                let signature = pair.as_str().trim_start_matches("event_signature ").trim();
+                Ok(EntityFilter::LogEventSignature(signature.to_string()))
+            }
             Rule::topic0_filter => {
                 let topic = pair.as_str().trim_start_matches("topic0 ").trim();
                 let topic = topic.parse::<B256>()?;

--- a/crates/core/src/common/entity_filter.rs
+++ b/crates/core/src/common/entity_filter.rs
@@ -23,13 +23,13 @@ impl<'a> TryFrom<Pair<'a, Rule>> for EntityFilter {
     fn try_from(pair: Pair<'a, Rule>) -> Result<Self, Self::Error> {
         match pair.as_rule() {
             Rule::address_filter => {
-                let tochecksum = pair.as_str().trim_start_matches("address ");
+                let tochecksum = pair.as_str().trim_start_matches("address ").trim();
                 let address = Address::parse_checksummed(tochecksum, None)
                     .map_err(|e| format!("{}: {}", e, tochecksum))?;
                 Ok(EntityFilter::LogEmitterAddress(address))
             },
             Rule::blockrange_filter => {
-                let range = pair.as_str().trim_start_matches("block ");
+                let range = pair.as_str().trim_start_matches("block ").trim();
                 let (start, end) = match range.split_once(":") {
                     //if ":" is present, we have an start and an end.
                     Some((start, end)) => (
@@ -54,7 +54,7 @@ impl EntityFilter {
         &self,
     ) -> Result<(BlockNumberOrTag, Option<BlockNumberOrTag>), EntityFilterError> {
         match self {
-            EntityFilter::BlockRange(block_id) => Ok((block_id.start.clone(), block_id.end.clone())),
+            EntityFilter::LogBlockRange(block_id) => Ok((block_id.start.clone(), block_id.end.clone())),
             _ => Err(EntityFilterError::InvalidBlockNumber),
         }
     }

--- a/crates/core/src/common/entity_id.rs
+++ b/crates/core/src/common/entity_id.rs
@@ -13,18 +13,6 @@ pub enum EntityId {
     Account(NameOrAddress),
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct BlockRange {
-    start: BlockNumberOrTag,
-    end: Option<BlockNumberOrTag>,
-}
-
-impl BlockRange {
-    pub fn new(start: BlockNumberOrTag, end: Option<BlockNumberOrTag>) -> Self {
-        Self { start, end }
-    }
-}
-
 // TODO: return instance of Error trait instead of &'static str
 impl TryFrom<&str> for EntityId {
     type Error = Box<dyn Error>;
@@ -58,27 +46,6 @@ impl TryFrom<&str> for EntityId {
             Ok(EntityId::Block(BlockRange { start, end }))
         }
     }
-}
-
-fn parse_block_number_or_tag(id: &str) -> Result<BlockNumberOrTag, EntityIdError> {
-    match id.parse::<u64>() {
-        Ok(id) => Ok(BlockNumberOrTag::Number(id)),
-        Err(_) => id
-            .parse::<BlockNumberOrTag>()
-            .map_err(|_| EntityIdError::InvalidBlockNumber),
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-pub enum EntityIdError {
-    #[error("Invalid address")]
-    InvalidAddress,
-    #[error("Invalid tx hash")]
-    InvalidTxHash,
-    #[error("Invalid block number")]
-    InvalidBlockNumber,
-    #[error("Unable resolve ENS name")]
-    EnsResolution,
 }
 
 impl EntityId {
@@ -120,5 +87,39 @@ impl EntityId {
             },
             _ => Err(EntityIdError::InvalidAddress),
         }
+    }
+}
+
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct BlockRange {
+    start: BlockNumberOrTag,
+    end: Option<BlockNumberOrTag>,
+}
+
+impl BlockRange {
+    pub fn new(start: BlockNumberOrTag, end: Option<BlockNumberOrTag>) -> Self {
+        Self { start, end }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum EntityIdError {
+    #[error("Invalid address")]
+    InvalidAddress,
+    #[error("Invalid tx hash")]
+    InvalidTxHash,
+    #[error("Invalid block number")]
+    InvalidBlockNumber,
+    #[error("Unable resolve ENS name")]
+    EnsResolution,
+}
+
+fn parse_block_number_or_tag(id: &str) -> Result<BlockNumberOrTag, EntityIdError> {
+    match id.parse::<u64>() {
+        Ok(id) => Ok(BlockNumberOrTag::Number(id)),
+        Err(_) => id
+            .parse::<BlockNumberOrTag>()
+            .map_err(|_| EntityIdError::InvalidBlockNumber),
     }
 }

--- a/crates/core/src/common/entity_id.rs
+++ b/crates/core/src/common/entity_id.rs
@@ -82,19 +82,6 @@ impl EntityId {
     }
 }
 
-
-// #[derive(Debug, PartialEq, Eq, Clone)]
-// pub struct BlockRange {
-//     start: BlockNumberOrTag,
-//     end: Option<BlockNumberOrTag>,
-// }
-
-// impl BlockRange {
-//     pub fn new(start: BlockNumberOrTag, end: Option<BlockNumberOrTag>) -> Self {
-//         Self { start, end }
-//     }
-// }
-
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum EntityIdError {
     #[error("Invalid address")]
@@ -108,7 +95,6 @@ pub enum EntityIdError {
 }
 
 //Do I need to repeat this here as well?
-
 fn parse_block_number_or_tag(id: &str) -> Result<BlockNumberOrTag, EntityIdError> {
     match id.parse::<u64>() {
         Ok(id) => Ok(BlockNumberOrTag::Number(id)),

--- a/crates/core/src/common/entity_id.rs
+++ b/crates/core/src/common/entity_id.rs
@@ -43,7 +43,7 @@ impl TryFrom<&str> for EntityId {
                 None => parse_block_number_or_tag(id).map(|start| (start, None))?,
             };
 
-            Ok(EntityId::Block(BlockRange { start, end }))
+            Ok(EntityId::Block(BlockRange::new(start, end)))
         }
     }
 }
@@ -53,7 +53,7 @@ impl EntityId {
         &self,
     ) -> Result<(BlockNumberOrTag, Option<BlockNumberOrTag>), EntityIdError> {
         match self {
-            EntityId::Block(block_id) => Ok((block_id.start.clone(), block_id.end.clone())),
+            EntityId::Block(block_id) => Ok(block_id.range()),
             _ => Err(EntityIdError::InvalidBlockNumber),
         }
     }
@@ -102,8 +102,8 @@ pub enum EntityIdError {
     EnsResolution,
 }
 
-//Do I need to repeat this here as well?
-fn parse_block_number_or_tag(id: &str) -> Result<BlockNumberOrTag, EntityIdError> {
+//Should it be moved to a separate module?
+pub fn parse_block_number_or_tag(id: &str) -> Result<BlockNumberOrTag, EntityIdError> {
     match id.parse::<u64>() {
         Ok(id) => Ok(BlockNumberOrTag::Number(id)),
         Err(_) => id

--- a/crates/core/src/common/mod.rs
+++ b/crates/core/src/common/mod.rs
@@ -2,6 +2,7 @@ pub mod chain;
 pub mod ens;
 pub mod entity;
 pub mod entity_id;
+pub mod entity_filter;
 pub mod query_builder;
 pub mod query_result;
 pub mod types;

--- a/crates/core/src/common/query_builder.rs
+++ b/crates/core/src/common/query_builder.rs
@@ -2,6 +2,7 @@ use super::{
     chain::Chain,
     entity::Entity,
     entity_id::EntityId,
+    entity_filter::EntityFilter,
     types::{Expression, Field, GetExpression},
 };
 use crate::interpreter::backend::execution_engine::{ExecutionEngine, QueryResult};
@@ -25,6 +26,7 @@ pub struct EQLBuilder {
     fields: Option<Vec<Field>>,
     entity: Option<Entity>,
     entity_id: Option<EntityId>,
+    entity_filter: Option<EntityFilter>,
     chain: Option<Chain>,
 }
 
@@ -34,6 +36,7 @@ impl EQLBuilder {
             fields: None,
             entity: None,
             entity_id: None,
+            entity_filter: None,
             chain: None,
         }
     }
@@ -43,11 +46,13 @@ impl EQLBuilder {
         self
     }
 
+    // I think this function will fail if I don't provide an entity_id, will need to come back here to fix it.
     pub fn from(&mut self, entity: Entity, entity_id: EntityId) -> &mut Self {
         self.entity = Some(entity);
         self.entity_id = Some(entity_id);
         self
     }
+    
 
     pub fn on(&mut self, chain: Chain) -> &mut Self {
         self.chain = Some(chain);
@@ -75,17 +80,21 @@ impl EQLBuilder {
             .ok_or(EQLBuilderError::MissingEntityError)?;
         let entity_id = self
             .entity_id
-            .clone()
-            .ok_or(EQLBuilderError::MissingEntityIdError)?;
+            .clone();
+            // .ok_or(EQLBuilderError::MissingEntityIdError)?;
         let chain = self
             .chain
             .clone()
             .ok_or(EQLBuilderError::MissingChainError)?;
+        let entity_filter = self
+            .entity_filter
+            .clone();
 
         Ok(Expression::Get(GetExpression {
             fields,
             entity,
             entity_id,
+            entity_filter,
             chain,
             query: "".to_string(),
         }))

--- a/crates/core/src/common/query_builder.rs
+++ b/crates/core/src/common/query_builder.rs
@@ -46,7 +46,6 @@ impl EQLBuilder {
         self
     }
 
-    // I think this function will fail if I don't provide an entity_id, will need to come back here to fix it.
     pub fn from(&mut self, entity: Entity, entity_id: EntityId) -> &mut Self {
         self.entity = Some(entity);
         self.entity_id = Some(entity_id);
@@ -81,7 +80,6 @@ impl EQLBuilder {
         let entity_id = self
             .entity_id
             .clone();
-            // .ok_or(EQLBuilderError::MissingEntityIdError)?;
         let chain = self
             .chain
             .clone()

--- a/crates/core/src/common/query_builder.rs
+++ b/crates/core/src/common/query_builder.rs
@@ -26,7 +26,7 @@ pub struct EQLBuilder {
     fields: Option<Vec<Field>>,
     entity: Option<Entity>,
     entity_id: Option<EntityId>,
-    entity_filter: Option<EntityFilter>,
+    entity_filter: Option<Vec<EntityFilter>>,
     chain: Option<Chain>,
 }
 

--- a/crates/core/src/common/query_builder.rs
+++ b/crates/core/src/common/query_builder.rs
@@ -26,7 +26,7 @@ pub struct EQLBuilder {
     fields: Option<Vec<Field>>,
     entity: Option<Entity>,
     entity_id: Option<EntityId>,
-    entity_filter: Option<Vec<EntityFilter>>,
+    entity_filters: Option<Vec<EntityFilter>>,
     chain: Option<Chain>,
 }
 
@@ -36,7 +36,7 @@ impl EQLBuilder {
             fields: None,
             entity: None,
             entity_id: None,
-            entity_filter: None,
+            entity_filters: None,
             chain: None,
         }
     }
@@ -51,7 +51,6 @@ impl EQLBuilder {
         self.entity_id = Some(entity_id);
         self
     }
-    
 
     pub fn on(&mut self, chain: Chain) -> &mut Self {
         self.chain = Some(chain);
@@ -85,7 +84,7 @@ impl EQLBuilder {
             .clone()
             .ok_or(EQLBuilderError::MissingChainError)?;
         let entity_filter = self
-            .entity_filter
+            .entity_filters
             .clone();
 
         Ok(Expression::Get(GetExpression {

--- a/crates/core/src/common/query_result.rs
+++ b/crates/core/src/common/query_result.rs
@@ -128,7 +128,7 @@ impl Default for TransactionQueryRes {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Debug, PartialEq, Eq, Tabled, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct LogQueryRes {
     pub address: Option<Address>,
     pub topic0: Option<FixedBytes<32>>,
@@ -136,7 +136,6 @@ pub struct LogQueryRes {
     pub topic2: Option<FixedBytes<32>>,
     pub topic3: Option<FixedBytes<32>>,
     pub data: Option<Bytes>,
-    #[serde(serialize_with = "serialize_option_u256")]
     pub block_hash: Option<B256>,
     pub block_number: Option<u64>,
     pub block_timestamp: Option<u64>,

--- a/crates/core/src/common/query_result.rs
+++ b/crates/core/src/common/query_result.rs
@@ -135,7 +135,6 @@ pub struct TransactionQueryRes {
     #[tabled(display_with = "display_option")]
     pub max_fee_per_blob_gas: Option<u128>,
     #[tabled(display_with = "display_option")]
-    #[tabled(display_with = "display_option")]
     pub max_fee_per_gas: Option<u128>,
     #[tabled(display_with = "display_option")]
     pub max_priority_fee_per_gas: Option<u128>,
@@ -163,6 +162,57 @@ impl Default for TransactionQueryRes {
             max_fee_per_gas: None,
             max_priority_fee_per_gas: None,
             y_parity: None,
+        }
+    }
+}
+
+// TODO: core structs shouldn't derive Tabled. It must be implemented on the CLI crate
+#[derive(Debug, PartialEq, Eq, Tabled, Serialize, Deserialize, Clone)]
+pub struct LogQueryRes {
+    #[tabled(display_with = "display_option")]
+    pub address: Option<Address>,
+    #[tabled(display_with = "display_option")]
+    pub topic0: Option<FixedBytes<32>>,
+    #[tabled(display_with = "display_option")]
+    pub topic1: Option<FixedBytes<32>>,
+    #[tabled(display_with = "display_option")]
+    pub topic2: Option<FixedBytes<32>>,
+    #[tabled(display_with = "display_option")]
+    pub topic3: Option<FixedBytes<32>>,
+    #[tabled(display_with = "display_option")]
+    pub data: Option<Bytes>,
+    #[tabled(display_with = "display_option")]
+    pub block_hash: Option<B256>,
+    #[tabled(display_with = "display_option")]
+    pub block_number: Option<u64>,
+    #[tabled(display_with = "display_option")]
+    pub block_timestamp: Option<u64>,
+    #[tabled(display_with = "display_option")]
+    pub transaction_hash: Option<B256>,
+    #[tabled(display_with = "display_option")]
+    pub transaction_index: Option<u64>,
+    #[tabled(display_with = "display_option")]
+    pub log_index: Option<u64>,
+    #[tabled(display_with = "display_option")]
+    pub removed: Option<bool>,
+}
+
+impl Default for LogQueryRes {
+    fn default() -> Self {
+        Self {
+            address: None,
+            topic0: None,
+            topic1: None,
+            topic2: None,
+            topic3: None,
+            data: None,
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            removed: None,
         }
     }
 }

--- a/crates/core/src/common/query_result.rs
+++ b/crates/core/src/common/query_result.rs
@@ -165,14 +165,6 @@ impl Default for LogQueryRes {
     }
 }
 
-// TODO: move to another file
-fn display_option<T: std::fmt::Display>(value: &Option<T>) -> String {
-    match value {
-        Some(value) => value.to_string(),
-        None => "-".to_string(),
-    }
-}
-
 #[cfg(test)]
 mod test {
     use std::str::FromStr;

--- a/crates/core/src/common/types.rs
+++ b/crates/core/src/common/types.rs
@@ -37,6 +37,7 @@ pub enum Field {
     Account(AccountField),
     Block(BlockField),
     Transaction(TransactionField),
+    Log(LogField),
 }
 
 impl Display for Field {
@@ -45,6 +46,7 @@ impl Display for Field {
             Field::Account(account_field) => write!(f, "{}", account_field),
             Field::Block(block_field) => write!(f, "{}", block_field),
             Field::Transaction(transaction_field) => write!(f, "{}", transaction_field),
+            Field::Log(log_field) => write!(f, "{}", log_field),
         }
     }
 }
@@ -184,6 +186,45 @@ impl TryFrom<&str> for TransactionField {
     }
 }
 
+impl TryFrom<&Field> for LogField {
+    type Error = Box<dyn Error>;
+
+    fn try_from(field: &Field) -> Result<Self, Self::Error> {
+        match field {
+            Field::Log(log_field) => Ok(*log_field),
+            invalid_field => Err(Box::new(FieldError::InvalidField(format!(
+                "Invalid field {:?} for entity log",
+                invalid_field
+            )))),
+        }
+    }
+}
+
+impl TryFrom<&str> for LogField{
+    type Error = Box<dyn Error>;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "address" => Ok(LogField::Address),
+            "topic0" => Ok(LogField::Topic0),
+            "topic1" => Ok(LogField::Topic1),
+            "topic2" => Ok(LogField::Topic2),
+            "topic3" => Ok(LogField::Topic3),
+            "data" => Ok(LogField::Data),
+            "block_hash" => Ok(LogField::BlockHash),
+            "block_number" => Ok(LogField::BlockNumber),
+            "block_timestamp" => Ok(LogField::BlockTimestamp),
+            "transaction_hash" => Ok(LogField::TransactionHash),
+            "transaction_index" => Ok(LogField::TransactionIndex),
+            "log_index" => Ok(LogField::LogIndex),
+            "removed" => Ok(LogField::Removed),
+            invalid_field => Err(Box::new(FieldError::InvalidField(
+                invalid_field.to_string(),
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum AccountField {
     Address,
@@ -291,6 +332,43 @@ impl std::fmt::Display for TransactionField {
             TransactionField::MaxFeePerGas => write!(f, "max_fee_per_gas"),
             TransactionField::MaxPriorityFeePerGas => write!(f, "max_priority_fee_per_gas"),
             TransactionField::YParity => write!(f, "y_parity"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LogField {
+    Address,
+    Topic0,
+    Topic1,
+    Topic2,
+    Topic3,
+    Data,
+    BlockHash,
+    BlockNumber,
+    BlockTimestamp,
+    TransactionHash,
+    TransactionIndex,
+    LogIndex,
+    Removed,
+}
+
+impl std::fmt::Display for LogField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogField::Address => write!(f, "address"),
+            LogField::Topic0 => write!(f, "topic0"),
+            LogField::Topic1 => write!(f, "topic1"),
+            LogField::Topic2 => write!(f, "topic2"),
+            LogField::Topic3 => write!(f, "topic3"),
+            LogField::Data => write!(f, "data"),
+            LogField::BlockHash => write!(f, "block_hash"),
+            LogField::BlockNumber => write!(f, "block_number"),
+            LogField::BlockTimestamp => write!(f, "block_timestamp"),
+            LogField::TransactionHash => write!(f, "transaction_hash"),
+            LogField::TransactionIndex => write!(f, "transaction_index"),
+            LogField::LogIndex => write!(f, "log_index"),
+            LogField::Removed => write!(f, "removed"),
         }
     }
 }

--- a/crates/core/src/common/types.rs
+++ b/crates/core/src/common/types.rs
@@ -340,7 +340,7 @@ impl std::fmt::Display for TransactionField {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum LogField {
     Address,
     Topic0,

--- a/crates/core/src/common/types.rs
+++ b/crates/core/src/common/types.rs
@@ -73,6 +73,25 @@ impl Error for FieldError {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+pub enum AccountField {
+    Address,
+    Nonce,
+    Balance,
+    Code,
+}
+
+impl Display for AccountField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AccountField::Address => write!(f, "address"),
+            AccountField::Nonce => write!(f, "nonce"),
+            AccountField::Balance => write!(f, "balance"),
+            AccountField::Code => write!(f, "code"),
+        }
+    }
+}
+
 impl TryFrom<&Field> for AccountField {
     type Error = Box<dyn Error>;
 
@@ -99,150 +118,6 @@ impl TryFrom<&str> for AccountField {
             invalid_field => Err(Box::new(FieldError::InvalidField(
                 invalid_field.to_string(),
             ))),
-        }
-    }
-}
-
-impl TryFrom<&Field> for BlockField {
-    type Error = Box<dyn Error>;
-
-    fn try_from(field: &Field) -> Result<Self, Self::Error> {
-        match field {
-            Field::Block(block_field) => Ok(*block_field),
-            invalid_field => Err(Box::new(FieldError::InvalidField(format!(
-                "Invalid field {:?} for entity block",
-                invalid_field
-            )))),
-        }
-    }
-}
-
-impl TryFrom<&str> for BlockField {
-    type Error = Box<dyn Error>;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "number" => Ok(BlockField::Number),
-            "timestamp" => Ok(BlockField::Timestamp),
-            "size" => Ok(BlockField::Size),
-            "hash" => Ok(BlockField::Hash),
-            "parent_hash" => Ok(BlockField::ParentHash),
-            "state_root" => Ok(BlockField::StateRoot),
-            "transactions_root" => Ok(BlockField::TransactionsRoot),
-            "receipts_root" => Ok(BlockField::ReceiptsRoot),
-            "logs_bloom" => Ok(BlockField::LogsBloom),
-            "extra_data" => Ok(BlockField::ExtraData),
-            "mix_hash" => Ok(BlockField::MixHash),
-            "total_difficulty" => Ok(BlockField::TotalDifficulty),
-            "base_fee_per_gas" => Ok(BlockField::BaseFeePerGas),
-            "withdrawals_root" => Ok(BlockField::WithdrawalsRoot),
-            "blob_gas_used" => Ok(BlockField::BlobGasUsed),
-            "excess_blob_gas" => Ok(BlockField::ExcessBlobGas),
-            "parent_beacon_block_root" => Ok(BlockField::ParentBeaconBlockRoot),
-            invalid_field => Err(Box::new(FieldError::InvalidField(
-                invalid_field.to_string(),
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&Field> for TransactionField {
-    type Error = Box<dyn Error>;
-
-    fn try_from(field: &Field) -> Result<Self, Self::Error> {
-        match field {
-            Field::Transaction(transaction_field) => Ok(*transaction_field),
-            invalid_field => Err(Box::new(FieldError::InvalidField(format!(
-                "Invalid field {:?} for entity transaction",
-                invalid_field
-            )))),
-        }
-    }
-}
-
-impl TryFrom<&str> for TransactionField {
-    type Error = Box<dyn Error>;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "transaction_type" => Ok(TransactionField::TransactionType),
-            "hash" => Ok(TransactionField::Hash),
-            "from" => Ok(TransactionField::From),
-            "to" => Ok(TransactionField::To),
-            "data" => Ok(TransactionField::Data),
-            "value" => Ok(TransactionField::Value),
-            "gas_price" => Ok(TransactionField::GasPrice),
-            "gas" => Ok(TransactionField::Gas),
-            "status" => Ok(TransactionField::Status),
-            "chain_id" => Ok(TransactionField::ChainId),
-            "v" => Ok(TransactionField::V),
-            "r" => Ok(TransactionField::R),
-            "s" => Ok(TransactionField::S),
-            "max_fee_per_blob_gas" => Ok(TransactionField::MaxFeePerBlobGas),
-            "max_fee_per_gas" => Ok(TransactionField::MaxFeePerGas),
-            "max_priority_fee_per_gas" => Ok(TransactionField::MaxPriorityFeePerGas),
-            "y_parity" => Ok(TransactionField::YParity),
-            invalid_field => Err(Box::new(FieldError::InvalidField(
-                invalid_field.to_string(),
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&Field> for LogField {
-    type Error = Box<dyn Error>;
-
-    fn try_from(field: &Field) -> Result<Self, Self::Error> {
-        match field {
-            Field::Log(log_field) => Ok(*log_field),
-            invalid_field => Err(Box::new(FieldError::InvalidField(format!(
-                "Invalid field {:?} for entity log",
-                invalid_field
-            )))),
-        }
-    }
-}
-
-impl TryFrom<&str> for LogField{
-    type Error = Box<dyn Error>;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "address" => Ok(LogField::Address),
-            "topic0" => Ok(LogField::Topic0),
-            "topic1" => Ok(LogField::Topic1),
-            "topic2" => Ok(LogField::Topic2),
-            "topic3" => Ok(LogField::Topic3),
-            "data" => Ok(LogField::Data),
-            "block_hash" => Ok(LogField::BlockHash),
-            "block_number" => Ok(LogField::BlockNumber),
-            "block_timestamp" => Ok(LogField::BlockTimestamp),
-            "transaction_hash" => Ok(LogField::TransactionHash),
-            "transaction_index" => Ok(LogField::TransactionIndex),
-            "log_index" => Ok(LogField::LogIndex),
-            "removed" => Ok(LogField::Removed),
-            invalid_field => Err(Box::new(FieldError::InvalidField(
-                invalid_field.to_string(),
-            ))),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
-pub enum AccountField {
-    Address,
-    Nonce,
-    Balance,
-    Code,
-}
-
-impl Display for AccountField {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AccountField::Address => write!(f, "address"),
-            AccountField::Nonce => write!(f, "nonce"),
-            AccountField::Balance => write!(f, "balance"),
-            AccountField::Code => write!(f, "code"),
         }
     }
 }
@@ -293,6 +168,49 @@ impl Display for BlockField {
     }
 }
 
+impl TryFrom<&Field> for BlockField {
+    type Error = Box<dyn Error>;
+
+    fn try_from(field: &Field) -> Result<Self, Self::Error> {
+        match field {
+            Field::Block(block_field) => Ok(*block_field),
+            invalid_field => Err(Box::new(FieldError::InvalidField(format!(
+                "Invalid field {:?} for entity block",
+                invalid_field
+            )))),
+        }
+    }
+}
+
+impl TryFrom<&str> for BlockField {
+    type Error = Box<dyn Error>;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "number" => Ok(BlockField::Number),
+            "timestamp" => Ok(BlockField::Timestamp),
+            "size" => Ok(BlockField::Size),
+            "hash" => Ok(BlockField::Hash),
+            "parent_hash" => Ok(BlockField::ParentHash),
+            "state_root" => Ok(BlockField::StateRoot),
+            "transactions_root" => Ok(BlockField::TransactionsRoot),
+            "receipts_root" => Ok(BlockField::ReceiptsRoot),
+            "logs_bloom" => Ok(BlockField::LogsBloom),
+            "extra_data" => Ok(BlockField::ExtraData),
+            "mix_hash" => Ok(BlockField::MixHash),
+            "total_difficulty" => Ok(BlockField::TotalDifficulty),
+            "base_fee_per_gas" => Ok(BlockField::BaseFeePerGas),
+            "withdrawals_root" => Ok(BlockField::WithdrawalsRoot),
+            "blob_gas_used" => Ok(BlockField::BlobGasUsed),
+            "excess_blob_gas" => Ok(BlockField::ExcessBlobGas),
+            "parent_beacon_block_root" => Ok(BlockField::ParentBeaconBlockRoot),
+            invalid_field => Err(Box::new(FieldError::InvalidField(
+                invalid_field.to_string(),
+            ))),
+        }
+    }
+}
+
 // TODO: implement blob_versioned_hashes and access_list
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum TransactionField {
@@ -339,6 +257,49 @@ impl std::fmt::Display for TransactionField {
     }
 }
 
+impl TryFrom<&Field> for TransactionField {
+    type Error = Box<dyn Error>;
+
+    fn try_from(field: &Field) -> Result<Self, Self::Error> {
+        match field {
+            Field::Transaction(transaction_field) => Ok(*transaction_field),
+            invalid_field => Err(Box::new(FieldError::InvalidField(format!(
+                "Invalid field {:?} for entity transaction",
+                invalid_field
+            )))),
+        }
+    }
+}
+
+impl TryFrom<&str> for TransactionField {
+    type Error = Box<dyn Error>;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "transaction_type" => Ok(TransactionField::TransactionType),
+            "hash" => Ok(TransactionField::Hash),
+            "from" => Ok(TransactionField::From),
+            "to" => Ok(TransactionField::To),
+            "data" => Ok(TransactionField::Data),
+            "value" => Ok(TransactionField::Value),
+            "gas_price" => Ok(TransactionField::GasPrice),
+            "gas" => Ok(TransactionField::Gas),
+            "status" => Ok(TransactionField::Status),
+            "chain_id" => Ok(TransactionField::ChainId),
+            "v" => Ok(TransactionField::V),
+            "r" => Ok(TransactionField::R),
+            "s" => Ok(TransactionField::S),
+            "max_fee_per_blob_gas" => Ok(TransactionField::MaxFeePerBlobGas),
+            "max_fee_per_gas" => Ok(TransactionField::MaxFeePerGas),
+            "max_priority_fee_per_gas" => Ok(TransactionField::MaxPriorityFeePerGas),
+            "y_parity" => Ok(TransactionField::YParity),
+            invalid_field => Err(Box::new(FieldError::InvalidField(
+                invalid_field.to_string(),
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum LogField {
     Address,
@@ -372,6 +333,45 @@ impl std::fmt::Display for LogField {
             LogField::TransactionIndex => write!(f, "transaction_index"),
             LogField::LogIndex => write!(f, "log_index"),
             LogField::Removed => write!(f, "removed"),
+        }
+    }
+}
+
+impl TryFrom<&Field> for LogField {
+    type Error = Box<dyn Error>;
+
+    fn try_from(field: &Field) -> Result<Self, Self::Error> {
+        match field {
+            Field::Log(log_field) => Ok(*log_field),
+            invalid_field => Err(Box::new(FieldError::InvalidField(format!(
+                "Invalid field {:?} for entity log",
+                invalid_field
+            )))),
+        }
+    }
+}
+
+impl TryFrom<&str> for LogField {
+    type Error = Box<dyn Error>;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "address" => Ok(LogField::Address),
+            "topic0" => Ok(LogField::Topic0),
+            "topic1" => Ok(LogField::Topic1),
+            "topic2" => Ok(LogField::Topic2),
+            "topic3" => Ok(LogField::Topic3),
+            "data" => Ok(LogField::Data),
+            "block_hash" => Ok(LogField::BlockHash),
+            "block_number" => Ok(LogField::BlockNumber),
+            "block_timestamp" => Ok(LogField::BlockTimestamp),
+            "transaction_hash" => Ok(LogField::TransactionHash),
+            "transaction_index" => Ok(LogField::TransactionIndex),
+            "log_index" => Ok(LogField::LogIndex),
+            "removed" => Ok(LogField::Removed),
+            invalid_field => Err(Box::new(FieldError::InvalidField(
+                invalid_field.to_string(),
+            ))),
         }
     }
 }

--- a/crates/core/src/common/types.rs
+++ b/crates/core/src/common/types.rs
@@ -4,7 +4,6 @@ use super::{
     entity_id::EntityId,
     entity_filter::EntityFilter,
 };
-use alloy::eips::BlockNumberOrTag;
 use serde::{Deserialize, Serialize};
 use std::{error::Error, fmt::Display};
 
@@ -27,7 +26,7 @@ impl Default for GetExpression {
     fn default() -> Self {
         Self {
             entity: Entity::Block,
-            entity_id: Some(EntityId::Block(BlockNumberOrTag::Latest)),
+            entity_id: None,
             entity_filter: None,
             fields: vec![],
             chain: Chain::Ethereum,

--- a/crates/core/src/common/types.rs
+++ b/crates/core/src/common/types.rs
@@ -1,7 +1,8 @@
 use super::{
     chain::Chain,
     entity::Entity,
-    entity_id::{BlockRange, EntityId},
+    entity_id::EntityId,
+    entity_filter::EntityFilter,
 };
 use alloy::eips::BlockNumberOrTag;
 use std::{error::Error, fmt::Display};
@@ -14,7 +15,8 @@ pub enum Expression {
 #[derive(Debug, PartialEq, Eq)]
 pub struct GetExpression {
     pub entity: Entity,
-    pub entity_id: EntityId,
+    pub entity_id: Option<EntityId>,
+    pub entity_filter: Option<EntityFilter>,
     pub fields: Vec<Field>,
     pub chain: Chain,
     pub query: String,
@@ -24,7 +26,8 @@ impl Default for GetExpression {
     fn default() -> Self {
         Self {
             entity: Entity::Block,
-            entity_id: EntityId::Block(BlockRange::new(BlockNumberOrTag::Earliest, None)),
+            entity_id: Some(EntityId::Block(BlockNumberOrTag::Latest)),
+            entity_filter: None,
             fields: vec![],
             chain: Chain::Ethereum,
             query: "".to_string(),

--- a/crates/core/src/common/types.rs
+++ b/crates/core/src/common/types.rs
@@ -16,7 +16,7 @@ pub enum Expression {
 pub struct GetExpression {
     pub entity: Entity,
     pub entity_id: Option<EntityId>,
-    pub entity_filter: Option<EntityFilter>,
+    pub entity_filter: Option<Vec<EntityFilter>>,
     pub fields: Vec<Field>,
     pub chain: Chain,
     pub query: String,

--- a/crates/core/src/interpreter/backend/execution_engine.rs
+++ b/crates/core/src/interpreter/backend/execution_engine.rs
@@ -86,7 +86,7 @@ impl ExecutionEngine {
                         panic!("Block filters don't support multiple filters"); // Check if this is the best approach for multiple filters. I understand it shouldn't panic.
                     }
                 } else {
-                    panic!("Invalid block_id"); 
+                    panic!("Neither a block_id nor a block filter was provided. Pest rules should have prevented this from happening."); 
                 };
         
                 
@@ -105,7 +105,7 @@ impl ExecutionEngine {
                 let address = if let Some(address_id) = &expr.entity_id {
                     address_id.to_address().await
                 } else {
-                    panic!("Invalid address");
+                    panic!("An address_id was not provided. Pest rules should have prevented this from happening.");
                 };
 
                 let fields = expr
@@ -127,7 +127,7 @@ impl ExecutionEngine {
                 let hash = if let Some(tx_id) = &expr.entity_id {
                     tx_id.to_tx_hash()
                 } else {
-                    panic!("Invalid transaction hash");
+                    panic!("A tx_id was not provided. Pest rules should have prevented this from happening.");
                 };
 
                 let fields = expr
@@ -153,7 +153,7 @@ impl ExecutionEngine {
                         filter = entity_filter.to_filter(filter)?;
                     };
                 } else {
-                    panic!("Invalid log filter");
+                    panic!("A log filter was not provided. Pest rules should have prevented this from happening.");
                 };
                 let fields = expr
                     .fields

--- a/crates/core/src/interpreter/backend/execution_engine.rs
+++ b/crates/core/src/interpreter/backend/execution_engine.rs
@@ -159,9 +159,10 @@ impl ExecutionEngine {
                     .collect::<Result<Vec<LogField>, _>>()?;
 
                 let log = self.get_logs(filter, fields, &provider).await?;
+
+                //need to return a range of logs
                 let mut log_query_res = vec![];
                 log_query_res.push(log);
-
                 Ok(ExpressionResult::Log(log_query_res))
                 
             }

--- a/crates/core/src/interpreter/backend/execution_engine.rs
+++ b/crates/core/src/interpreter/backend/execution_engine.rs
@@ -342,8 +342,9 @@ mod test {
             entity: Entity::Log,
             entity_id: None,
             entity_filter: Some(vec![
-                EntityFilter::LogBlockRange(BlockRange::new(BlockNumberOrTag::Number(20526954), Some(BlockNumberOrTag::Number(20526970)))),
-                EntityFilter::LogEmitterAddress(Address::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap()),
+                EntityFilter::LogBlockRange(BlockRange::new(BlockNumberOrTag::Number(4638757), Some(BlockNumberOrTag::Number(4638758)))),
+                EntityFilter::LogEmitterAddress(address!("dac17f958d2ee523a2206206994597c13d831ec7")),
+                EntityFilter::LogTopic0(b256!("cb8241adb0c3fdb35b70c24ce35c5eb0c17af7431c99f827d44a445ca624176a")),
             ]),
             fields: vec![
                 Field::Log(LogField::Address),
@@ -362,8 +363,28 @@ mod test {
             query: String::from(""),
         })];
         let execution_result = execution_engine.run(expressions).await; 
+        let expected = vec![LogQueryRes {
+            address: Some(address!("dac17f958d2ee523a2206206994597c13d831ec7")),
+            topic0: Some(b256!("cb8241adb0c3fdb35b70c24ce35c5eb0c17af7431c99f827d44a445ca624176a")),
+            topic1: None,
+            topic2: None,
+            topic3: None,
+            data: Some(bytes!("00000000000000000000000000000000000000000000000000000002540be400")),
+            block_hash: Some(b256!("d34e3b2957865fe76c73ec91d798f78de95f2b0e0cddfc47e341b5f235dc4d58")),
+            block_number: Some(4638757),
+            block_timestamp: Some(1511886266),
+            transaction_hash: Some(b256!("8cfc4f5f4729423f59dd1d263ead2f824b3f133b02b9e27383964c7d50cd47cb")),
+            transaction_index: Some(9),
+            log_index: Some(5),
+            removed: None,
+        }];
 
-        println!("{:#?}", execution_result);
+        match execution_result {
+            Ok(results) => {
+                assert_eq!(results[0].result, ExpressionResult::Log(expected));
+            }
+            Err(_) => panic!("Error"),
+        }
     }
 
 

--- a/crates/core/src/interpreter/backend/execution_engine.rs
+++ b/crates/core/src/interpreter/backend/execution_engine.rs
@@ -1,6 +1,7 @@
 use super::block_resolver::resolve_block_query;
 use crate::common::{
     entity::{Entity, EntityError},
+    entity_filter::EntityFilter,
     query_result::{AccountQueryRes, BlockQueryRes, TransactionQueryRes, LogQueryRes},
     types::{AccountField, BlockField, TransactionField, LogField, Expression, GetExpression},
 };
@@ -147,11 +148,8 @@ impl ExecutionEngine {
                 }
             }
             Entity::Log => {
-                let mut filter = Filter::new();
-                if let Some(entity_filter) = &expr.entity_filter{
-                    for entity_filter in entity_filter {
-                        filter = entity_filter.to_filter(filter)?;
-                    };
+                let filter = if let Some(entity_filter) = &expr.entity_filter {
+                    EntityFilter::build_filter(entity_filter)                
                 } else {
                     panic!("A log filter was not provided. Pest rules should have prevented this from happening.");
                 };

--- a/crates/core/src/interpreter/backend/execution_engine.rs
+++ b/crates/core/src/interpreter/backend/execution_engine.rs
@@ -98,7 +98,8 @@ impl ExecutionEngine {
                     .map(|field| field.try_into())
                     .collect::<Result<Vec<BlockField>, _>>()?;
 
-                let block_query_res = resolve_block_query(start_block, end_block, fields, &provider).await?;
+                let block_query_res = 
+                    resolve_block_query(start_block, end_block, fields, &provider).await?;
 
                 Ok(ExpressionResult::Block(block_query_res))
             }
@@ -345,7 +346,12 @@ impl ExecutionEngine {
 mod test {
     use super::*;
     use crate::common::{
-        chain::Chain, ens::NameOrAddress, entity_filter::{BlockRange, EntityFilter}, entity_id::EntityId, query_result::BlockQueryRes, types::{AccountField, BlockField, Expression, Field, GetExpression}
+        chain::Chain,
+        ens::NameOrAddress,
+        entity_id::EntityId,
+        entity_filter::{BlockRange, EntityFilter},
+        query_result::BlockQueryRes,
+        types::{AccountField, BlockField, Expression, Field, GetExpression},
     };
     use alloy::{
         eips::BlockNumberOrTag,

--- a/crates/core/src/interpreter/backend/execution_engine.rs
+++ b/crates/core/src/interpreter/backend/execution_engine.rs
@@ -83,7 +83,7 @@ impl ExecutionEngine {
                         let (start_block, end_block) = entity_filter[0].to_block_range()?;
                         (start_block, end_block)
                     } else {
-                        panic!("Block filters don't support multiple filters"); // Check if this is the best approach for multiple filters. I understand it shouldn't panic.
+                        return Err("Block filters don't support multiple filters".into()); // Check if this is the best approach for multiple filters.
                     }
                 } else {
                     panic!("Neither a block_id nor a block filter was provided. Pest rules should have prevented this from happening."); 
@@ -338,7 +338,6 @@ mod test {
 
     #[tokio::test]
     async fn test_get_logs() {
-        // let contract_address = Address::from_str("0x3c11f6265ddec22f4d049dde480615735f451646").unwrap();
         let execution_engine = ExecutionEngine::new();
         let expressions = vec![Expression::Get(GetExpression {
             chain: Chain::Ethereum,
@@ -346,7 +345,7 @@ mod test {
             entity_id: None,
             entity_filter: Some(vec![
                 EntityFilter::LogBlockRange(BlockRange::new(BlockNumberOrTag::Number(20526954), Some(BlockNumberOrTag::Number(20526970)))),
-                // EntityFilter::LogEmitterAddress(Address::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap()),
+                EntityFilter::LogEmitterAddress(Address::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap()),
             ]),
             fields: vec![
                 Field::Log(LogField::Address),

--- a/crates/core/src/interpreter/backend/execution_engine.rs
+++ b/crates/core/src/interpreter/backend/execution_engine.rs
@@ -34,7 +34,7 @@ pub enum ExpressionResult {
     #[serde(rename = "transaction")]
     Transaction(TransactionQueryRes),
     #[serde(rename = "log")]
-    Log(LogQueryRes),
+    Log(Vec<LogQueryRes>),
 }
 
 pub struct ExecutionEngine;
@@ -159,7 +159,11 @@ impl ExecutionEngine {
                     .collect::<Result<Vec<LogField>, _>>()?;
 
                 let log = self.get_logs(filter, fields, &provider).await?;
-                Ok(ExpressionResult::Log(log))
+                let mut log_query_res = vec![];
+                log_query_res.push(log);
+
+                Ok(ExpressionResult::Log(log_query_res))
+                
             }
         }
     }

--- a/crates/core/src/interpreter/backend/execution_engine.rs
+++ b/crates/core/src/interpreter/backend/execution_engine.rs
@@ -77,9 +77,7 @@ impl ExecutionEngine {
                 //If neither entity_id nor entity_filter is present in expr, the code panics with the message "Invalid block_id".
      
                 let (start_block, end_block) = if let Some(entity_id) = &expr.entity_id {
-                    let start_block = entity_id.to_block_id()?;
-                    let end_block= None;
-                    (start_block, end_block)
+                    entity_id.to_block_id()?
                 } else if let Some(entity_filter) = &expr.entity_filter {
                     if entity_filter.len() == 1 {
                         let (start_block, end_block) = entity_filter[0].to_block_range()?;
@@ -404,7 +402,7 @@ mod test {
         let expressions = vec![Expression::Get(GetExpression {
             chain: Chain::Ethereum,
             entity: Entity::Block,
-            entity_id: Some(EntityId::Block(BlockNumberOrTag::Number(1))),
+            entity_id: Some(EntityId::Block(BlockRange::new(BlockNumberOrTag::Number(1), None))),
             entity_filter: None,
             fields: vec![
                 Field::Block(BlockField::Timestamp),

--- a/crates/core/src/interpreter/frontend/parser.rs
+++ b/crates/core/src/interpreter/frontend/parser.rs
@@ -210,7 +210,6 @@ mod tests {
         }
     }
 
-    //Need to run this test, because I think it will fail. 
     #[test]
     fn test_build_get_ast_using_block_ranges() {
         let source = "GET timestamp FROM block 1:2 ON eth";

--- a/crates/core/src/interpreter/frontend/parser.rs
+++ b/crates/core/src/interpreter/frontend/parser.rs
@@ -125,7 +125,7 @@ mod tests {
     };
     use alloy::{
         eips::BlockNumberOrTag,
-        primitives::{b256, Address},
+        primitives::{b256, address, Address},
     };
     use std::str::FromStr;
 
@@ -264,6 +264,65 @@ mod tests {
             chain: Chain::Ethereum,
             query: source.to_string(),
         })];
+
+        match Parser::new(source).parse_expressions() {
+            Ok(result) => assert_eq!(result, expected),
+            Err(e) => panic!("Error: {}", e),
+        }
+    }
+
+    #[test]
+    fn test_build_ast_with_log_fields() {
+        let source = "GET address, topic0, topic1, topic2, topic3, data, block_hash, block_number, block_timestamp, transaction_hash, transaction_index, log_index, removed FROM log WHERE block 4638757, address 0xdAC17F958D2ee523a2206206994597C13D831ec7, topic0 0xcb8241adb0c3fdb35b70c24ce35c5eb0c17af7431c99f827d44a445ca624176a ON eth,
+        GET address FROM log WHERE block_hash 0xedb7f4a64744594838f7d9888883ae964fcb4714f6fe5cafb574d3ed6141ad5b, topic0 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef, topic1 0x00000000000000000000000036928500Bc1dCd7af6a2B4008875CC336b927D57, topic2 0x000000000000000000000000C6CDE7C39eB2f0F0095F41570af89eFC2C1Ea828 ON eth";
+
+        let expected = vec![
+            Expression::Get(GetExpression {
+                entity: Entity::Log,
+                entity_id: None,
+                entity_filter: Some(
+                    vec![
+                        EntityFilter::LogBlockRange(BlockRange::new(BlockNumberOrTag::Number(4638757), None)),
+                        EntityFilter::LogEmitterAddress(address!("dac17f958d2ee523a2206206994597c13d831ec7")),
+                        EntityFilter::LogTopic0(b256!("cb8241adb0c3fdb35b70c24ce35c5eb0c17af7431c99f827d44a445ca624176a")),
+                    ],
+                ),
+                fields: vec![
+                    Field::Log(LogField::Address),
+                    Field::Log(LogField::Topic0),
+                    Field::Log(LogField::Topic1),
+                    Field::Log(LogField::Topic2),
+                    Field::Log(LogField::Topic3),
+                    Field::Log(LogField::Data),
+                    Field::Log(LogField::BlockHash),
+                    Field::Log(LogField::BlockNumber),
+                    Field::Log(LogField::BlockTimestamp),
+                    Field::Log(LogField::TransactionHash),
+                    Field::Log(LogField::TransactionIndex),
+                    Field::Log(LogField::LogIndex),
+                    Field::Log(LogField::Removed),
+                ],
+                chain: Chain::Ethereum,
+                query: "GET address, topic0, topic1, topic2, topic3, data, block_hash, block_number, block_timestamp, transaction_hash, transaction_index, log_index, removed FROM log WHERE block 4638757, address 0xdAC17F958D2ee523a2206206994597C13D831ec7, topic0 0xcb8241adb0c3fdb35b70c24ce35c5eb0c17af7431c99f827d44a445ca624176a ON eth,\n        ".to_string()}),
+                
+            Expression::Get(GetExpression {
+                entity: Entity::Log,
+                entity_id: None,
+                entity_filter: Some(
+                    vec![
+                        EntityFilter::LogBlockHash(b256!("edb7f4a64744594838f7d9888883ae964fcb4714f6fe5cafb574d3ed6141ad5b")),
+                        EntityFilter::LogTopic0(b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")),
+                        EntityFilter::LogTopic1(b256!("00000000000000000000000036928500bc1dcd7af6a2b4008875cc336b927d57")),
+                        EntityFilter::LogTopic2(b256!("000000000000000000000000c6cde7c39eb2f0f0095f41570af89efc2c1ea828")),
+                    ],
+                ),
+                fields: vec![
+                    Field::Log(LogField::Address),
+                ],
+                chain: Chain::Ethereum,
+                query: "GET address FROM log WHERE block_hash 0xedb7f4a64744594838f7d9888883ae964fcb4714f6fe5cafb574d3ed6141ad5b, topic0 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef, topic1 0x00000000000000000000000036928500Bc1dCd7af6a2B4008875CC336b927D57, topic2 0x000000000000000000000000C6CDE7C39eB2f0F0095F41570af89eFC2C1Ea828 ON eth".to_string()}),
+                
+                ];
 
         match Parser::new(source).parse_expressions() {
             Ok(result) => assert_eq!(result, expected),

--- a/crates/core/src/interpreter/frontend/parser.rs
+++ b/crates/core/src/interpreter/frontend/parser.rs
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn test_build_ast_with_log_fields() {
         let source = "GET address, topic0, topic1, topic2, topic3, data, block_hash, block_number, block_timestamp, transaction_hash, transaction_index, log_index, removed FROM log WHERE block 4638757, address 0xdAC17F958D2ee523a2206206994597C13D831ec7, topic0 0xcb8241adb0c3fdb35b70c24ce35c5eb0c17af7431c99f827d44a445ca624176a ON eth,
-        GET address FROM log WHERE block_hash 0xedb7f4a64744594838f7d9888883ae964fcb4714f6fe5cafb574d3ed6141ad5b, topic0 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef, topic1 0x00000000000000000000000036928500Bc1dCd7af6a2B4008875CC336b927D57, topic2 0x000000000000000000000000C6CDE7C39eB2f0F0095F41570af89eFC2C1Ea828 ON eth";
+        GET address FROM log WHERE block_hash 0xedb7f4a64744594838f7d9888883ae964fcb4714f6fe5cafb574d3ed6141ad5b, event_signature Transfer(address,address,uint256), topic1 0x00000000000000000000000036928500Bc1dCd7af6a2B4008875CC336b927D57, topic2 0x000000000000000000000000C6CDE7C39eB2f0F0095F41570af89eFC2C1Ea828 ON eth";
 
         let expected = vec![
             Expression::Get(GetExpression {
@@ -311,7 +311,7 @@ mod tests {
                 entity_filter: Some(
                     vec![
                         EntityFilter::LogBlockHash(b256!("edb7f4a64744594838f7d9888883ae964fcb4714f6fe5cafb574d3ed6141ad5b")),
-                        EntityFilter::LogTopic0(b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")),
+                        EntityFilter::LogEventSignature(String::from("Transfer(address,address,uint256)")),
                         EntityFilter::LogTopic1(b256!("00000000000000000000000036928500bc1dcd7af6a2b4008875cc336b927d57")),
                         EntityFilter::LogTopic2(b256!("000000000000000000000000c6cde7c39eb2f0f0095f41570af89efc2c1ea828")),
                     ],
@@ -320,7 +320,7 @@ mod tests {
                     Field::Log(LogField::Address),
                 ],
                 chain: Chain::Ethereum,
-                query: "GET address FROM log WHERE block_hash 0xedb7f4a64744594838f7d9888883ae964fcb4714f6fe5cafb574d3ed6141ad5b, topic0 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef, topic1 0x00000000000000000000000036928500Bc1dCd7af6a2B4008875CC336b927D57, topic2 0x000000000000000000000000C6CDE7C39eB2f0F0095F41570af89eFC2C1Ea828 ON eth".to_string()}),
+                query: "GET address FROM log WHERE block_hash 0xedb7f4a64744594838f7d9888883ae964fcb4714f6fe5cafb574d3ed6141ad5b, event_signature Transfer(address,address,uint256), topic1 0x00000000000000000000000036928500Bc1dCd7af6a2B4008875CC336b927D57, topic2 0x000000000000000000000000C6CDE7C39eB2f0F0095F41570af89eFC2C1Ea828 ON eth".to_string()}),
                 
                 ];
 

--- a/crates/core/src/interpreter/frontend/parser.rs
+++ b/crates/core/src/interpreter/frontend/parser.rs
@@ -120,7 +120,7 @@ mod tests {
         chain::Chain,
         ens::NameOrAddress,
         entity::Entity,
-        entity_filter::{EntityFilter, BlockRange},
+        entity_filter::BlockRange,
         entity_id::EntityId, types::*
     };
     use alloy::{
@@ -210,17 +210,17 @@ mod tests {
         }
     }
 
-    //Need to run this test, because I think it will fail.
+    //Need to run this test, because I think it will fail. 
     #[test]
     fn test_build_get_ast_using_block_ranges() {
         let source = "GET timestamp FROM block 1:2 ON eth";
         let expected = vec![Expression::Get(GetExpression {
             entity: Entity::Block,
-            entity_id: None,
-            entity_filter: Some(vec![EntityFilter::BlockRange(BlockRange::new(
+            entity_id: Some(EntityId::Block(BlockRange::new(
                 BlockNumberOrTag::Number(1),
                 Some(BlockNumberOrTag::Number(2)),
-            ))]),
+            ))),
+            entity_filter: None,
             fields: vec![Field::Block(BlockField::Timestamp)],
             chain: Chain::Ethereum,
             query: source.to_string(),

--- a/crates/core/src/interpreter/frontend/parser.rs
+++ b/crates/core/src/interpreter/frontend/parser.rs
@@ -207,10 +207,10 @@ mod tests {
         let expected = vec![Expression::Get(GetExpression {
             entity: Entity::Block,
             entity_id: None,
-            entity_filter: Some(EntityFilter::Block(BlockRange::new(
+            entity_filter: Some(vec![EntityFilter::BlockRange(BlockRange::new(
                 BlockNumberOrTag::Number(1),
                 Some(BlockNumberOrTag::Number(2)),
-            ))),
+            ))]),
             fields: vec![Field::Block(BlockField::Timestamp)],
             chain: Chain::Ethereum,
             query: source.to_string(),

--- a/crates/core/src/interpreter/frontend/parser.rs
+++ b/crates/core/src/interpreter/frontend/parser.rs
@@ -180,7 +180,7 @@ mod tests {
 
         let expected = vec![Expression::Get(GetExpression {
             entity: Entity::Block,
-            entity_id: Some(EntityId::Block(BlockNumberOrTag::Number(1))),
+            entity_id: Some(EntityId::Block(BlockRange::new(BlockNumberOrTag::Number(1), None))),
             entity_filter: None,
             fields: vec![
                 Field::Block(BlockField::ParentHash),

--- a/crates/core/src/interpreter/frontend/parser.rs
+++ b/crates/core/src/interpreter/frontend/parser.rs
@@ -1,8 +1,6 @@
-use crate::common::entity_filter::{BlockRange, EntityFilter};
+use crate::common::entity_filter::EntityFilter;
 use crate::common::types::{Expression, Field, GetExpression};
-use alloy::eips::BlockNumberOrTag;
-use alloy::primitives::Address;
-use pest::iterators::{Pair, Pairs};
+use pest::iterators::Pairs;
 use pest::Parser as PestParser;
 use pest_derive::Parser as DeriveParser;
 use std::error::Error;
@@ -70,9 +68,9 @@ impl<'a> Parser<'a> {
                 Rule::entity_id => get_expr.entity_id = Some(pair.as_str().trim().try_into()?),
                 Rule::entity_filter => {
                     get_expr.entity_filter = Some(pair
-                    .into_inner()
-                    .map(|pair| self.get_filter(pair))
-                    .collect::<Result<Vec<_>, _>>()?);
+                        .into_inner()
+                        .map(|pair| pair.try_into())
+                        .collect::<Result<Vec<EntityFilter>, _>>()?);
                 } 
                 Rule::chain => get_expr.chain = pair.as_str().try_into()?,
                 _ => {
@@ -84,25 +82,6 @@ impl<'a> Parser<'a> {
         }
 
         Ok(get_expr)
-    }
-
-    fn get_filter(&self, pair: Pair<Rule>) -> Result<EntityFilter, Box<dyn Error>> {
-        match pair.as_rule() {
-            Rule::address_filter => {
-                let tochecksum = pair.into_inner().as_str();
-                let address = Address::parse_checksummed(tochecksum, None)
-                .map_err(|e| format!("{}: {}", e, tochecksum))?;
-                Ok(EntityFilter::LogEmitterAddress(address))
-            },
-            Rule::blockrange_filter => {
-                //in the unwraps below, the parser garantee that we won't have an error.
-                let (start, end) = pair.into_inner().as_str().split_once(":").unwrap();
-                let start = BlockNumberOrTag::Number(start.parse::<u64>().unwrap());
-                let end = Some(BlockNumberOrTag::Number(end.parse::<u64>().unwrap()));
-                Ok(EntityFilter::LogBlockRange(BlockRange::new(start, end)))
-            }
-            _ => Err(Box::new(ParserError::UnexpectedToken(pair.as_str().to_string())))
-        }
     }
 
     fn get_fields(&self, pairs: Pairs<Rule>) -> Result<Vec<Field>, Box<dyn Error>> {

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -104,6 +104,7 @@ log_filter = _{
    |topic3_filter
    |blockhash_filter
    |blockrange_filter
+   |event_signature_filter
 }
 
 //Filters
@@ -114,16 +115,20 @@ topic2_filter = {"topic2" ~ hash}
 topic3_filter = {"topic3" ~ hash}
 blockhash_filter = {("blockhash" | "block_hash") ~ hash}
 blockrange_filter = {"block" ~ block_id}
+event_signature_filter ={"event_signature" ~ function_signature}
    
 // Terminals
 unit = { "ether" | "gwei" | "wei" }
-number = { float | integer }
-integer = { (ASCII_DIGIT)+ }
-float = { integer ~ "." ~ integer }
+number = _{ float | integer }
+integer = _{ (ASCII_DIGIT)+ }
+float = _{ integer ~ "." ~ integer }
 chain = { "eth" | "arb" | "op" | "base" | "blast" | "polygon" | "sepolia" }
 address = { "0x" ~ (ASCII_HEX_DIGIT){40} }
 hash = { "0x" ~ (ASCII_HEX_DIGIT){64} }
 ens = { (ASCII_ALPHANUMERIC)+ ~ ".eth" }
+function_signature = { ASCII_ALPHANUMERIC+ ~ "(" ~ solidity_type* ~ ("," ~ solidity_type)* ~ ")" }
+solidity_type = _{ ("uint" ~ size | "uint[]" | "uint" ) | ("bytes" ~ size | "bytes[]" | "bytes" ) | ("int" ~ size | "int[]" | "int" ) | ("address" ~ "[]"*) | "string" | "bool" }
+size = _{integer ~ "[]"*}
 
 // Helpers
 WHITESPACE = _{ " " | "\t" | NEWLINE }

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -6,8 +6,8 @@ get       = {
 fields    = { (account_field_list | block_field_list | tx_field_list | log_field_list) }
 entity    = { "account" | "block" | "tx" | "log" }
 entity_id = { hash | account_id | block_id }
-filter = { "WHERE" ~ WHITESPACE* ~ entity_filter}
-entity_filter = { log_filter_list }
+filter = _{ "WHERE" ~ WHITESPACE* ~ entity_filter}
+entity_filter = { log_filter_list | block_filter_list | tx_filter_list}
 
 // Account
 account_field_list = _{ account_field ~ (", " ~ account_field)* }
@@ -16,7 +16,7 @@ account_field = {
     "balance" |
     "code"
 }
-account_id = { address | ens }
+account_id = _{ address | ens }
 
 // Block
 block_field_list = _{ block_field ~ (", " ~ block_field_list)* }
@@ -40,8 +40,12 @@ block_field      =  {
     "parent_beacon_block_root" |
     "size"
 }
-block_id    = { block_tag ~ ":" ~ block_tag | block_tag }
-block_tag = { "latest" | "earliest" | "pending" | "finalized" | "safe" | integer }
+block_id    = _{ block_tag ~ ":" ~ block_tag | block_tag }
+block_tag = _{ "latest" | "earliest" | "pending" | "finalized" | "safe" | integer }
+block_filter_list = _{ block_filter ~ (", " ~ block_filter)* }
+block_filter = _{
+    blockrange_filter
+}
 
 // Transaction
 tx_field_list = _{ tx_field ~ (", " ~ tx_field)* }
@@ -74,6 +78,11 @@ tx_field = {
     "y_parity"
 }
 
+tx_filter_list = _{ tx_filter ~ (", " ~ tx_filter)* }
+tx_filter = _{
+   blockrange_filter
+}
+
 // Log
 log_field_list = _{ log_field ~ (", " ~ log_field)* }
 log_field      =  {
@@ -85,20 +94,26 @@ log_field      =  {
    |"data"
    |"blockhash"
    |"blocknumber"
-   |"blocktimestamp"
+   |"block_timestamp"
    |"transactionhash"
    |"transactionindex"
    |"logindex"
    |"removed"
 }
 log_filter_list = _{ log_filter ~ (", " ~ log_filter)* }
-log_filter = {
-    ("address" ~ address)
-   |("topic0" ~ hash)
-   |("blockhash" ~ hash)
-   |("block" ~ block_id)
+log_filter = _{
+    address_filter
+   |topic0_filter
+   |blockhash_filter
+   |blockrange_filter
 }
 
+//Filters
+address_filter = {"address" ~ address}
+topic0_filter = {"topic0" ~ hash}
+blockhash_filter = {"blockhash" ~ hash}
+blockrange_filter = {"block" ~ block_id}
+   
 // Terminals
 unit = { "ether" | "gwei" | "wei" }
 number = { float | integer }
@@ -113,4 +128,3 @@ ens = { (ASCII_ALPHANUMERIC)+ ~ ".eth" }
 WHITESPACE = _{ " " | "\t" | NEWLINE }
 exp_separator = _{"," | ";"}
 silent_eoi = _{ !ANY }
-

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -1,11 +1,13 @@
 program = _{SOI ~ (get){1, } ~ silent_eoi}
 
 get       = {
-    "GET" ~ WHITESPACE* ~ fields* ~ WHITESPACE* ~ "FROM" ~ WHITESPACE* ~ entity ~ WHITESPACE* ~ entity_id ~ WHITESPACE* ~ "ON" ~ WHITESPACE* ~ chain ~ exp_separator* ~ WHITESPACE*
+    "GET" ~ WHITESPACE* ~ fields* ~ WHITESPACE* ~ "FROM" ~ WHITESPACE* ~ entity ~ WHITESPACE* ~ (entity_id | filter) ~ WHITESPACE* ~ "ON" ~ WHITESPACE* ~ chain ~ exp_separator* ~ WHITESPACE*
 }
-fields    = { (account_field_list | block_field_list | tx_field_list) }
-entity    = { "account" | "block" | "tx" }
-entity_id = { hash | account_id | integer }
+fields    = { (account_field_list | block_field_list | tx_field_list | log_field_list) }
+entity    = { "account" | "block" | "tx" | "log" }
+entity_id = { hash | account_id | block_id }
+filter = { "WHERE" ~ WHITESPACE* ~ entity_filter}
+entity_filter = { log_filter_list }
 
 // Account
 account_field_list = _{ account_field ~ (", " ~ account_field)* }
@@ -70,6 +72,31 @@ tx_field = {
     // EIP-2930
     "access_list" |
     "y_parity"
+}
+
+// Log
+log_field_list = _{ log_field ~ (", " ~ log_field)* }
+log_field      =  {
+    "address"
+   |"topic0"
+   |"topic1"
+   |"topic2"
+   |"topic3"
+   |"data"
+   |"blockhash"
+   |"blocknumber"
+   |"blocktimestamp"
+   |"transactionhash"
+   |"transactionindex"
+   |"logindex"
+   |"removed"
+}
+log_filter_list = _{ log_filter ~ (", " ~ log_filter)* }
+log_filter = {
+    ("address" ~ address)
+   |("topic0" ~ hash)
+   |("blockhash" ~ hash)
+   |("block" ~ block_id)
 }
 
 // Terminals

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -104,6 +104,9 @@ log_filter_list = _{ log_filter ~ (", " ~ log_filter)* }
 log_filter = _{
     address_filter
    |topic0_filter
+   |topic1_filter
+   |topic2_filter
+   |topic3_filter
    |blockhash_filter
    |blockrange_filter
 }
@@ -111,7 +114,10 @@ log_filter = _{
 //Filters
 address_filter = {"address" ~ address}
 topic0_filter = {"topic0" ~ hash}
-blockhash_filter = {"blockhash" ~ hash}
+topic1_filter = {"topic1" ~ hash}
+topic2_filter = {"topic2" ~ hash}
+topic3_filter = {"topic3" ~ hash}
+blockhash_filter = {("blockhash" | "block_hash") ~ hash}
 blockrange_filter = {"block" ~ block_id}
    
 // Terminals

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -81,30 +81,30 @@ tx_field = {
 // Log
 log_field_list = _{ log_field ~ (", " ~ log_field)* }
 log_field      =  {
-    "address"
-   |"topic0"
-   |"topic1"
-   |"topic2"
-   |"topic3"
-   |"data"
-   |"block_hash"
-   |"block_number"
-   |"block_timestamp"
-   |"transaction_hash"
-   |"transaction_index"
-   |"log_index"
-   |"removed"
+    "address" |
+    "topic0" |
+    "topic1" |
+    "topic2" |
+    "topic3" |
+    "data" |
+    "block_hash" |
+    "block_number" |
+    "block_timestamp" |
+    "transaction_hash" |
+    "transaction_index" |
+    "log_index" |
+    "removed"
 }
 log_filter_list = _{ log_filter ~ (", " ~ log_filter)* }
 log_filter = _{
-    address_filter
-   |topic0_filter
-   |topic1_filter
-   |topic2_filter
-   |topic3_filter
-   |blockhash_filter
-   |blockrange_filter
-   |event_signature_filter
+    address_filter |
+    topic0_filter |
+    topic1_filter |
+    topic2_filter |
+    topic3_filter |
+    blockhash_filter |
+    blockrange_filter |
+    event_signature_filter
 }
 
 //Filters
@@ -113,7 +113,7 @@ topic0_filter = {"topic0" ~ hash}
 topic1_filter = {"topic1" ~ hash}
 topic2_filter = {"topic2" ~ hash}
 topic3_filter = {"topic3" ~ hash}
-blockhash_filter = {("blockhash" | "block_hash") ~ hash}
+blockhash_filter = {"block_hash" ~ hash}
 blockrange_filter = {"block" ~ block_id}
 event_signature_filter ={"event_signature" ~ function_signature}
    
@@ -127,7 +127,7 @@ address = { "0x" ~ (ASCII_HEX_DIGIT){40} }
 hash = { "0x" ~ (ASCII_HEX_DIGIT){64} }
 ens = { (ASCII_ALPHANUMERIC)+ ~ ".eth" }
 function_signature = { ASCII_ALPHANUMERIC+ ~ "(" ~ solidity_type* ~ ("," ~ solidity_type)* ~ ")" }
-solidity_type = _{ ("uint" ~ size | "uint[]" | "uint" ) | ("bytes" ~ size | "bytes[]" | "bytes" ) | ("int" ~ size | "int[]" | "int" ) | ("address" ~ "[]"*) | "string" | "bool" }
+solidity_type = _{ ("uint" ~ size | "uint[]" | "uint" ) | ("bytes" ~ size | "bytes[]" | "bytes" ) | ("int" ~ size | "int[]" | "int" ) | ("address" ~ "[]"*) | ("string" ~ "[]"*) | "bool" }
 size = _{integer ~ "[]"*}
 
 // Helpers

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -92,12 +92,12 @@ log_field      =  {
    |"topic2"
    |"topic3"
    |"data"
-   |"blockhash"
-   |"blocknumber"
+   |"block_hash"
+   |"block_number"
    |"block_timestamp"
-   |"transactionhash"
-   |"transactionindex"
-   |"logindex"
+   |"transaction_hash"
+   |"transaction_index"
+   |"log_index"
    |"removed"
 }
 log_filter_list = _{ log_filter ~ (", " ~ log_filter)* }

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -7,7 +7,7 @@ fields    = { (account_field_list | block_field_list | tx_field_list | log_field
 entity    = { "account" | "block" | "tx" | "log" }
 entity_id = { hash | account_id | block_id }
 filter = _{ "WHERE" ~ WHITESPACE* ~ entity_filter}
-entity_filter = { log_filter_list | block_filter_list | tx_filter_list}
+entity_filter = { log_filter_list | block_filter_list}
 
 // Account
 account_field_list = _{ account_field ~ (", " ~ account_field)* }
@@ -76,11 +76,6 @@ tx_field = {
     // EIP-2930
     "access_list" |
     "y_parity"
-}
-
-tx_filter_list = _{ tx_filter ~ (", " ~ tx_filter)* }
-tx_filter = _{
-   blockrange_filter
 }
 
 // Log

--- a/crates/core/src/interpreter/frontend/sementic_analyzer.rs
+++ b/crates/core/src/interpreter/frontend/sementic_analyzer.rs
@@ -75,7 +75,7 @@ impl<'a> SemanticAnalyzer<'a> {
                     }
                 }
                 Field::Log(_) => {
-                    if get_expr.entity != Entity::Transaction {
+                    if get_expr.entity != Entity::Log {
                         return Err(Box::new(SemanticError::InvalidField {
                             field: field.clone(),
                             enetity: get_expr.entity.clone(),

--- a/crates/core/src/interpreter/frontend/sementic_analyzer.rs
+++ b/crates/core/src/interpreter/frontend/sementic_analyzer.rs
@@ -101,9 +101,10 @@ mod test {
     fn test_analyze_get_expression_with_wrong_fields() {
         let expressions = vec![Expression::Get(GetExpression {
             entity: Entity::Account,
-            entity_id: "0x1234567890123456789012345678901234567890"
+            entity_id: Some("0x1234567890123456789012345678901234567890"
                 .try_into()
-                .unwrap(),
+                .unwrap()),
+            entity_filter: None,
             chain: Chain::Ethereum,
             fields: vec![Field::Block(BlockField::Number)],
             // The query doesn't matter for this test

--- a/crates/core/src/interpreter/frontend/sementic_analyzer.rs
+++ b/crates/core/src/interpreter/frontend/sementic_analyzer.rs
@@ -35,6 +35,10 @@ impl<'a> SemanticAnalyzer<'a> {
     }
 
     // TODO: fields should only contain fields that are valid for the entity
+    // TODO: entity_id should correspond  to the entity
+    // TODO: entity_filter should only contain filters that are valid for the entity
+    // TODO: Warn if entity_filter is overring previous filters
+    // TODO: Check if either a block_hash or block_range is provided in log queries
     pub fn analyze(&self) -> Result<(), Box<dyn Error>> {
         for expression in self.expressions {
             match expression {

--- a/crates/core/src/interpreter/frontend/sementic_analyzer.rs
+++ b/crates/core/src/interpreter/frontend/sementic_analyzer.rs
@@ -74,6 +74,14 @@ impl<'a> SemanticAnalyzer<'a> {
                         }));
                     }
                 }
+                Field::Log(_) => {
+                    if get_expr.entity != Entity::Transaction {
+                        return Err(Box::new(SemanticError::InvalidField {
+                            field: field.clone(),
+                            enetity: get_expr.entity.clone(),
+                        }));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
# Summary

Resolve #30. This PR allows EQL users to make EQL expressions to retrieve logs like:
```
GET 
  address, 
  topic0,
  topic1,
  topic2,
  topic3,  
  data,
  block_hash, 
  block_number, 
  block_timestamp, 
  transaction_hash, 
  transaction_index, 
  log_index
FROM log 
WHERE 
  block 20577221:latest,
  address 0x0000000000000000000000000000000000000000,
  topic0 0x0000000000000000000000000000000000000000,
  topic1 0x0000000000000000000000000000000000000000,
ON eth
```

Logs can't be retrieved by a `LOG_ID`, even though `(BLOCK_ID + LOG_INDEX)` are unique. Instead, logs need to be filtered using the `WHERE` clause. The accepted filters are:
- `(BLOCK_HASH OR BLOCK_RANGE)` AND/OR 
- `ADDRESS` AND/OR 
- `TOPIC0` to `TOPIC3`

Logs indexing and the available filters are defined in protocol (Bloom Filter). The protocol, thus RPCs, also imposed a limitation of only scanning a range of 10k blocks, making either `BLOCK_HASH` OR `BLOCK_RANGE` required.

## Technical details:

### entity_filter.rs
Filters were handled by a new `EntityFilter` Enum, in the `entity_filter.rs` file. It's very similar to `EntityID`. The `EntityFilter` Enum implements 2 methods:
- `to_block_range`: creates a `block_range` tupple, which already existed for `EntityID` but was transferred into `EntityFilter`.
- `to_filter`: creates a [Alloy::Filter](https://docs.rs/alloy/0.2.0/alloy/rpc/types/struct.Filter.html) Struct, that filters the `Alloy::get_logs` function with the desire params.

The `EntityFilter` Enum also implements a `Try_From` trait to allow the conversion of [Pest::Pair](https://docs.rs/pest/latest/pest/iterators/struct.Pair.html) Struct into a `EntityFilter`. Notice here that the approach was different from `EntityID`, which converts from `str`, because the text of the `Pair` for topics, block_hash are similar (hash).

The PR kept the ability of `BlockRange ` Structs to be created from `EntityId`, but renamed the function to `to_block_id`. This makes `GET * FROM block 1:10 ON eth`, which results in a similar behavior to `GET * FROM block WHERE block 1:10 ON eth`.

### types.rs
In the `GetExpression` Struct type, the `entity_filter` field was added as an `Option<Vec<EntityFilter>>`. The `entity_id` became an optional field. Both defaults are `None`, and the pest imposes you to define one of them.

Also, in `types.rs`, a new `LogField` enum was defined, following the same other field types, with `Try_From` traits for conversion.

### execution_engine.rs

While running an expression, for any Entity type, we now need to handle the case in which it can be None. This case should never happen, as the existing Pest's rules prevent it.

When running block expressions, there is a more complex logic involved. First, the program checks if an `entity_id` was provided and then calls the `to_block_id` function on EntityId to create a block range. If no `entity_id` was provided, the program checks if an `entity_filter` exists and then calls the `to_block_range` function on EntityFilter. The program panics if more than one filter is provided. The situation in which neither `entity_id` nor `entity_filter` was provided is handled by the Pest rules.

When running log expressions, the program will apply each filter expression successively. A known issue is that nothing prevents the user from creating conflicting filters. In this case, this logic will override the previous filter, and only the last expressions will be valid without warning the user. 

execution_engine also implements the actual `get_logs` method, by calling the [Alloy::Provider.get_logs](https://docs.rs/alloy/0.2.0/alloy/providers/trait.Provider.html#method.get_logs). The resulting `Vec<Alloy::Log>`, is then fed into the `Vec<LogQueryRes>` which contains all the parsed `LogFields`. The topics array is flattened into a specific LogField for each topic.

### productions.pest
The pest file implements some new rules. The GET expression now needs to include either `entity_id | filter`.

A filter rule is defined by "WHERE" ~ entity_filter, which in turn can be of the `entity_filter = { log_filter_list | block_filter_list | tx_filter_list}`. Only `log_filter_list` and `block_filter_list` have been implemented so far.

It also introduces the Logs Rules: log_fields, log_filter, and adds them to the previous other rules.

Finally, an improvement was made to make all auxiliary rules silent by adding an underscore. Anything that is not parsed from a pair to a rust struct, became silent.

### parser.rs
In its turn, the `parser.rs` file is responsible for converting the newly generated Pest::Pairs into rust structs, by using the previously mentioned `Try_From` traits. 

### sementic_analyzer.rs (shouldn't it be semantic_analyzer?)
sementic_analyzer still needs some love. Many TODOs here, which would improve the whole program.
- Entity_id should correspond to the entity
- Entity_filter should only contain filters that are valid for the entity
- Warn if entity_filter is overring previous filters
- Check if either a block_hash or block_range is provided in log queries

Right now, it only extends the function, which checks if the Field belongs to their Entity.