### PR TITLE
Add support to star operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,6 +1287,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "csv",
+ "eql_macros",
  "getrandom",
  "pest",
  "pest_derive",
@@ -1296,6 +1297,15 @@ dependencies = [
  "serde_with",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "eql_macros"
+version = "0.1.1-alpha"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/cli", "crates/core", "crates/wasm"]
+members = ["crates/cli", "crates/core", "crates/wasm", "crates/macros"]
 resolver = "2"
 
 [workspace.package]
@@ -13,6 +13,7 @@ authors = ["Ian K. Guimaraes <ianguimaraes31@gmail.com>"]
 eql_core = { path = "crates/core" }
 eql_cli = { path = "crates/cli" }
 eql_wasm = { path = "crates/wasm" }
+eql_macros = { path = "crates/macros" }
 
 [profile.bench]
 debug = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = { version = "0.1" }
 getrandom = { version = "0.2", features = ["js"] }
 csv = "1.1"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
+eql_macros = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/crates/core/src/common/types.rs
+++ b/crates/core/src/common/types.rs
@@ -124,6 +124,7 @@ pub enum Field {
     Block(BlockField),
     Transaction(TransactionField),
     Log(LogField),
+    Star,
 }
 
 impl Display for Field {
@@ -133,6 +134,7 @@ impl Display for Field {
             Field::Block(block_field) => write!(f, "{}", block_field),
             Field::Transaction(transaction_field) => write!(f, "{}", transaction_field),
             Field::Log(log_field) => write!(f, "{}", log_field),
+            Field::Star => write!(f, "*"),
         }
     }
 }

--- a/crates/core/src/common/types.rs
+++ b/crates/core/src/common/types.rs
@@ -1,6 +1,7 @@
 use crate::interpreter::frontend::parser::Rule;
 
 use super::{chain::Chain, entity::Entity, entity_filter::EntityFilter, entity_id::EntityId};
+use eql_macros::EnumVariants;
 use pest::iterators::Pair;
 use serde::{Deserialize, Serialize};
 use std::{error::Error, fmt::Display};
@@ -158,8 +159,7 @@ impl Error for FieldError {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
-pub enum AccountField {
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, EnumVariants)]pub enum AccountField {
     Address,
     Nonce,
     Balance,
@@ -208,7 +208,7 @@ impl TryFrom<&str> for AccountField {
 }
 
 // TODO: should include nonce, transactions and withdrawals
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, EnumVariants)]
 pub enum BlockField {
     Number,
     Timestamp,
@@ -297,7 +297,7 @@ impl TryFrom<&str> for BlockField {
 }
 
 // TODO: implement blob_versioned_hashes and access_list
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, EnumVariants)]
 pub enum TransactionField {
     TransactionType,
     Hash,
@@ -385,7 +385,7 @@ impl TryFrom<&str> for TransactionField {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, EnumVariants)]
 pub enum LogField {
     Address,
     Topic0,

--- a/crates/core/src/interpreter/backend/execution_engine.rs
+++ b/crates/core/src/interpreter/backend/execution_engine.rs
@@ -5,8 +5,10 @@ use crate::common::{
     query_result::{
         AccountQueryRes, ExpressionResult, LogQueryRes, QueryResult, TransactionQueryRes,
     },
-    serializer::{dump_results, serialize_results},
-    types::{AccountField, BlockField, Expression, Field, GetExpression, LogField, TransactionField},
+    serializer::dump_results,
+    types::{
+        AccountField, BlockField, Expression, Field, GetExpression, LogField, TransactionField,
+    },
 };
 use alloy::{
     primitives::{Address, FixedBytes},
@@ -70,33 +72,12 @@ impl ExecutionEngine {
                 };
 
                 let fields = match &expr.fields[0] {
-                    Field::Star => {
-                        vec![
-                            BlockField::Timestamp,
-                            BlockField::Hash,
-                            BlockField::ParentHash,
-                            BlockField::Size,
-                            BlockField::StateRoot,
-                            BlockField::TransactionsRoot,
-                            BlockField::ReceiptsRoot,
-                            BlockField::LogsBloom,
-                            BlockField::ExtraData,
-                            BlockField::MixHash,
-                            BlockField::TotalDifficulty,
-                            BlockField::BaseFeePerGas,
-                            BlockField::WithdrawalsRoot,
-                            BlockField::BlobGasUsed,
-                            BlockField::ExcessBlobGas,
-                            BlockField::ParentBeaconBlockRoot,
-                        ]
-                    },
-                    _ => {
-                        expr
-                            .fields
-                            .iter()
-                            .map(|field| field.try_into())
-                            .collect::<Result<Vec<BlockField>, _>>()?
-                    }
+                    Field::Star => BlockField::all_variants().to_vec(),
+                    _ => expr
+                        .fields
+                        .iter()
+                        .map(|field| field.try_into())
+                        .collect::<Result<Vec<BlockField>, _>>()?,
                 };
 
                 let block_query_res =
@@ -112,21 +93,12 @@ impl ExecutionEngine {
                 };
 
                 let fields = match expr.fields[0] {
-                    Field::Star => {
-                        vec![
-                            AccountField::Address,
-                            AccountField::Nonce,
-                            AccountField::Balance,
-                            AccountField::Code,
-                        ]
-                    },
-                    _ => {
-                        expr
-                            .fields
-                            .iter()
-                            .map(|field| field.try_into())
-                            .collect::<Result<Vec<AccountField>, _>>()?
-                    }
+                    Field::Star => AccountField::all_variants().to_vec(),
+                    _ => expr
+                        .fields
+                        .iter()
+                        .map(|field| field.try_into())
+                        .collect::<Result<Vec<AccountField>, _>>()?,
                 };                
                 
                 match address {
@@ -147,34 +119,12 @@ impl ExecutionEngine {
                 };
                 
                 let fields = match expr.fields[0] {
-                    Field::Star => {
-                        vec![
-                            TransactionField::TransactionType,
-                            TransactionField::Hash,
-                            TransactionField::From,
-                            TransactionField::To,
-                            TransactionField::Data,
-                            TransactionField::Value,
-                            TransactionField::GasPrice,
-                            TransactionField::Gas,
-                            TransactionField::Status,
-                            TransactionField::ChainId,
-                            TransactionField::V,
-                            TransactionField::R,
-                            TransactionField::S,
-                            TransactionField::MaxFeePerBlobGas,
-                            TransactionField::MaxFeePerGas,
-                            TransactionField::MaxPriorityFeePerGas,
-                            TransactionField::YParity,
-                        ]
-                    },
-                    _ => {
-                        expr
-                            .fields
-                            .iter()
-                            .map(|field| field.try_into())
-                            .collect::<Result<Vec<TransactionField>, _>>()?
-                    }
+                    Field::Star => TransactionField::all_variants().to_vec(),
+                    _ => expr
+                        .fields
+                        .iter()
+                        .map(|field| field.try_into())
+                        .collect::<Result<Vec<TransactionField>, _>>()?,
                 };
 
                 match hash {
@@ -195,27 +145,13 @@ impl ExecutionEngine {
                 };
                 
                 let fields = match expr.fields[0] {
-                    Field::Star => vec![
-                        LogField::Address,
-                        LogField::Topic0,
-                        LogField::Topic1,
-                        LogField::Topic2,
-                        LogField::Topic3,
-                        LogField::Data,
-                        LogField::BlockHash,
-                        LogField::BlockNumber,
-                        LogField::BlockTimestamp,
-                        LogField::TransactionHash,
-                        LogField::TransactionIndex,
-                        LogField::LogIndex,
-                        LogField::Removed,
-                    ],
+                    Field::Star => LogField::all_variants().to_vec(),
                     _ => expr
                         .fields
                         .iter()
                         .map(|field| field.try_into())
                         .collect::<Result<Vec<LogField>, _>>()?,
-                }; 
+                };
 
                 let logs = self.get_logs(filter, fields, &provider).await?;
                 Ok(ExpressionResult::Log(logs))
@@ -620,7 +556,7 @@ mod test {
             nonce: Some(1307),
             balance: Some(U256::from(11712705339518332754_u64)),
             address: Some(address!("d8da6bf26964af9d7eed9e03e53415d37aa96045")),
-            code: Some(bytes!(""))
+            code: Some(bytes!("")),
         }]);
 
         let execution_result = execution_engine.run(expressions).await;

--- a/crates/core/src/interpreter/frontend/parser.rs
+++ b/crates/core/src/interpreter/frontend/parser.rs
@@ -104,6 +104,9 @@ impl<'a> Parser<'a> {
                 Rule::log_field => {
                     fields.push(Field::Log(pair.as_str().try_into()?));
                 }
+                Rule::star_operator => {
+                    fields.push(Field::Star);
+                }
                 _ => {
                     return Err(Box::new(ParserError::UnexpectedToken(
                         pair.as_str().to_string(),

--- a/crates/core/src/interpreter/frontend/productions.pest
+++ b/crates/core/src/interpreter/frontend/productions.pest
@@ -19,7 +19,7 @@ get       = {
     WHITESPACE*
 }
 
-fields    = { (account_field_list | block_field_list | tx_field_list | log_field_list) }
+fields    = { (star_operator | account_field_list | block_field_list | tx_field_list | log_field_list) }
 entity    = { "account" | "block" | "tx" | "log" }
 entity_id = { hash | account_id | block_id }
 
@@ -189,3 +189,4 @@ size = _{integer ~ "[]"*}
 WHITESPACE = _{ " " | "\t" | NEWLINE }
 exp_separator = _{"," | ";"}
 silent_eoi = _{ !ANY }
+star_operator = { "*" }

--- a/crates/core/src/interpreter/frontend/sementic_analyzer.rs
+++ b/crates/core/src/interpreter/frontend/sementic_analyzer.rs
@@ -86,6 +86,7 @@ impl<'a> SemanticAnalyzer<'a> {
                         }));
                     }
                 }
+                Field::Star => {} 
             }
         }
 

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "eql_macros"
+description = "Procedural macros for the eql"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+
+[dependencies]
+quote = "1.0"
+syn = "1.0"
+proc-macro2 = "1.0"
+
+[lib]
+proc-macro = true

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,0 +1,30 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput};
+
+#[proc_macro_derive(EnumVariants)]
+pub fn enum_variants_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let variants = match input.data {
+        Data::Enum(data_enum) => data_enum.variants,
+        _ => panic!("EnumVariants can only be applied to enums"),
+    };
+
+    let variant_names = variants.iter().map(|variant| &variant.ident);
+
+    let expanded = quote! {
+        impl #name {
+            pub fn all_variants() -> &'static [#name] {
+                &[
+                    #( #name::#variant_names, )*
+                ]
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}


### PR DESCRIPTION
# Summary
<!--Please include a summary of the changes and the motivation behind them.-->
This PR adds support for a star operator `*` (wildcard operator), which adds all the entity's fields.
Examples:
```
GET * 
FROM 
  account 0x1234567890123456789012345678901234567890
ON eth
```

## Related Issue
<!--Please link to the issue here-->
Close issue #17 

## Technical details
<!--Summarize the solution and provide any necessary context such as file changes, functions created, libraries added and anything needed to understand the code change.-->
### productions.pest
Added `star_operator` to the list of accepted fields.

### parser.rs
Added a variant `Star` to the Field Enum. That's what goes in the `get_expr` struct instance, since up to this point, we don't know the expression Entity.

### execution_engine.rs
Before creating the fields instance, it test if the `expr.fields` is the star operator. If true, the adds all the fields of that Entidy, if not, it follow the regular flow.

## Topics for Discussion
<!--This is an open space for contributors to outline any decisions made, improvements yet to be made, or unresolved points that could be discussed.-->
- maybe new logic that identifies the star operator and parse fields should be moved to the field implementation (type.rs) or some other file.
- Should we make a more complex logic to add all the fields already in the parsed expression (parsed.rs file)? 

## PR Checklist

-   [x] Added Tests
-   [x] Cargo Tests Passing
-   [ ] Added Documentation
-   [ ] Breaking changes

## Screenshots (if applicable)
<!--Include screenshots or relevant links to visual changes here.-->
![image](https://github.com/user-attachments/assets/519ed664-b3f2-4021-8c7d-12b7d165babe)

