### PR TITLE
feat: allow non-checksum formatted values in the WHERE clause for logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "eql_core"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "alloy",
  "anyhow",

--- a/crates/core/src/common/logs.rs
+++ b/crates/core/src/common/logs.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use super::{
     block::BlockRange,
     entity_id::{parse_block_number_or_tag, EntityIdError},
@@ -140,7 +142,7 @@ impl TryFrom<Pair<'_, Rule>> for LogFilter {
         match pair.as_rule() {
             Rule::address_filter_type => extract_value(pair, |s| {
                 Ok(LogFilter::EmitterAddress(Address::parse_checksummed(
-                    s, None,
+                    Address::to_checksum(&Address::from_str(s)?, None), None,
                 )?))
             }),
             Rule::blockrange_filter => parse_block_range(pair),


### PR DESCRIPTION
Should close #53 

Added the checksum encoding before trying to parse the address. This ensures that the `Address::parse_checksummed` does not produce an `AddressError::InvalidChecksum` error when dealing with valid addresses.

Tests pass with the `cargo test` with the changes applied. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and parsing logic for log filters.
	- Improved address formatting and validation in log processing.

- **Bug Fixes**
	- Centralized logic for extracting values from pairs to improve error reporting.

- **Documentation**
	- Updated method signatures for clarity in error handling and parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->