### PR TITLE
Write typed Parquet columns instead of all-varchar

### DIFF
--- a/crates/core/src/common/serializer.rs
+++ b/crates/core/src/common/serializer.rs
@@ -491,17 +491,16 @@ fn transaction_columns(rows: &[TransactionQueryRes]) -> Result<Vec<Column>, Box<
         )?,
     );
     push(&mut cols, bool_col("y_parity", col(rows, |r| r.y_parity)));
-    push(
-        &mut cols,
-        str_col(
-            "authorization_list",
-            col(rows, |r| {
-                r.authorization_list
-                    .as_ref()
-                    .map(|a| serde_json::to_string(a).unwrap_or_default())
-            }),
-        ),
-    );
+    let authorization_list = rows
+        .iter()
+        .map(|r| {
+            r.authorization_list
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    push(&mut cols, str_col("authorization_list", authorization_list));
     Ok(cols)
 }
 

--- a/crates/core/src/common/serializer.rs
+++ b/crates/core/src/common/serializer.rs
@@ -11,7 +11,7 @@ use super::{
 use alloy::primitives::U256;
 use arrow::array::{ArrayRef, BooleanArray, Decimal128Array, StringArray, UInt64Array, UInt8Array};
 use arrow::datatypes::{DataType, Field, Schema};
-use arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
 use serde::Serialize;
 
@@ -113,27 +113,19 @@ fn serialize_csv<T: Serialize>(results: &Vec<T>) -> Result<String, Box<dyn Error
 }
 
 fn serialize_parquet(result: &ExpressionResult) -> Result<Vec<u8>, Box<dyn Error>> {
-    let (columns, num_rows) = match result {
-        ExpressionResult::Account(rows) => (account_columns(rows)?, rows.len()),
-        ExpressionResult::Block(rows) => (block_columns(rows)?, rows.len()),
-        ExpressionResult::Transaction(rows) => (transaction_columns(rows)?, rows.len()),
-        ExpressionResult::Log(rows) => (log_columns(rows)?, rows.len()),
-    };
+    let mut columns = entity_columns(result, false)?;
+
+    // No columns means an empty result, or a query whose selected fields were
+    // all null. A zero-column Parquet file is malformed — readers reject it
+    // ("Need at least one non-root column") — so emit the entity's full schema
+    // with zero rows instead: a valid, empty, readable table.
+    if columns.is_empty() {
+        columns = entity_columns(result, true)?;
+    }
 
     let (fields, arrays): (Vec<Field>, Vec<ArrayRef>) = columns.into_iter().unzip();
     let schema = Arc::new(Schema::new(fields));
-
-    // With no columns (an empty result, or a query whose selected fields are
-    // all null) Arrow can't infer the row count from the arrays, so pass it.
-    let batch = if arrays.is_empty() {
-        RecordBatch::try_new_with_options(
-            schema.clone(),
-            arrays,
-            &RecordBatchOptions::new().with_row_count(Some(num_rows)),
-        )?
-    } else {
-        RecordBatch::try_new(schema.clone(), arrays)?
-    };
+    let batch = RecordBatch::try_new(schema.clone(), arrays)?;
 
     let mut buf = Vec::new();
     let mut writer = ArrowWriter::try_new(&mut buf, schema, None)?;
@@ -142,6 +134,23 @@ fn serialize_parquet(result: &ExpressionResult) -> Result<Vec<u8>, Box<dyn Error
     writer.close()?;
 
     Ok(buf)
+}
+
+/// Typed columns for `result`. With `schema_only`, the builders run over no
+/// rows, which (via `skip`) keeps every field and so yields the full typed
+/// schema as zero-row columns.
+fn entity_columns(
+    result: &ExpressionResult,
+    schema_only: bool,
+) -> Result<Vec<Column>, Box<dyn Error>> {
+    match result {
+        ExpressionResult::Account(rows) => account_columns(if schema_only { &[] } else { rows }),
+        ExpressionResult::Block(rows) => block_columns(if schema_only { &[] } else { rows }),
+        ExpressionResult::Transaction(rows) => {
+            transaction_columns(if schema_only { &[] } else { rows })
+        }
+        ExpressionResult::Log(rows) => log_columns(if schema_only { &[] } else { rows }),
+    }
 }
 
 // --- Typed Parquet columns ---------------------------------------------------
@@ -158,6 +167,14 @@ fn all_none<T>(vals: &[Option<T>]) -> bool {
     vals.iter().all(Option::is_none)
 }
 
+/// Whether to drop a column: only when it has rows and every one is null (an
+/// all-null *populated* field). Empty `vals` — a result with no rows — keeps
+/// the column, so an empty result still yields the full typed schema rather
+/// than a malformed zero-column file.
+fn skip<T>(vals: &[Option<T>]) -> bool {
+    !vals.is_empty() && all_none(vals)
+}
+
 fn col<R, T>(rows: &[R], f: impl Fn(&R) -> Option<T>) -> Vec<Option<T>> {
     rows.iter().map(f).collect()
 }
@@ -169,7 +186,7 @@ fn push(cols: &mut Vec<Column>, column: Option<Column>) {
 }
 
 fn u64_col(name: &str, vals: Vec<Option<u64>>) -> Option<Column> {
-    if all_none(&vals) {
+    if skip(&vals) {
         return None;
     }
     Some((
@@ -179,7 +196,7 @@ fn u64_col(name: &str, vals: Vec<Option<u64>>) -> Option<Column> {
 }
 
 fn u8_col(name: &str, vals: Vec<Option<u8>>) -> Option<Column> {
-    if all_none(&vals) {
+    if skip(&vals) {
         return None;
     }
     Some((
@@ -189,7 +206,7 @@ fn u8_col(name: &str, vals: Vec<Option<u8>>) -> Option<Column> {
 }
 
 fn bool_col(name: &str, vals: Vec<Option<bool>>) -> Option<Column> {
-    if all_none(&vals) {
+    if skip(&vals) {
         return None;
     }
     Some((
@@ -199,7 +216,7 @@ fn bool_col(name: &str, vals: Vec<Option<bool>>) -> Option<Column> {
 }
 
 fn str_col(name: &str, vals: Vec<Option<String>>) -> Option<Column> {
-    if all_none(&vals) {
+    if skip(&vals) {
         return None;
     }
     Some((
@@ -217,7 +234,7 @@ fn str_col(name: &str, vals: Vec<Option<String>>) -> Option<Column> {
 /// test-net balance — falls back to lossless decimal strings rather than being
 /// truncated. Full-range signature fields (`r`/`s`) are always decimal strings.
 fn u256_col(name: &str, vals: Vec<Option<U256>>) -> Result<Option<Column>, Box<dyn Error>> {
-    if all_none(&vals) {
+    if skip(&vals) {
         return Ok(None);
     }
     // 10^38 is Decimal128(38, 0)'s exclusive upper bound.
@@ -248,7 +265,7 @@ fn u256_to_i128(value: U256) -> Result<i128, Box<dyn Error>> {
 /// gas value. A value at/above 10^38 (never a real gas price) can't fit and
 /// makes the column fall back to lossless decimal strings, same as `u256_col`.
 fn u128_col(name: &str, vals: Vec<Option<u128>>) -> Result<Option<Column>, Box<dyn Error>> {
-    if all_none(&vals) {
+    if skip(&vals) {
         return Ok(None);
     }
     let limit = 10u128.pow(38);
@@ -287,7 +304,7 @@ fn account_columns(rows: &[AccountQueryRes]) -> Result<Vec<Column>, Box<dyn Erro
         &mut cols,
         str_col(
             "address",
-            col(rows, |r| r.address.as_ref().map(|a| format!("{a:?}"))),
+            col(rows, |r| r.address.as_ref().map(|a| format!("{a:#x}"))),
         ),
     );
     push(
@@ -434,14 +451,14 @@ fn transaction_columns(rows: &[TransactionQueryRes]) -> Result<Vec<Column>, Box<
         &mut cols,
         str_col(
             "from_address",
-            col(rows, |r| r.from_address.as_ref().map(|a| format!("{a:?}"))),
+            col(rows, |r| r.from_address.as_ref().map(|a| format!("{a:#x}"))),
         ),
     );
     push(
         &mut cols,
         str_col(
             "to_address",
-            col(rows, |r| r.to_address.as_ref().map(|a| format!("{a:?}"))),
+            col(rows, |r| r.to_address.as_ref().map(|a| format!("{a:#x}"))),
         ),
     );
     push(
@@ -491,6 +508,8 @@ fn transaction_columns(rows: &[TransactionQueryRes]) -> Result<Vec<Column>, Box<
         )?,
     );
     push(&mut cols, bool_col("y_parity", col(rows, |r| r.y_parity)));
+    // Serialize the authorization list to JSON, propagating any error rather
+    // than swallowing it into an empty string.
     let authorization_list = rows
         .iter()
         .map(|r| {
@@ -499,7 +518,7 @@ fn transaction_columns(rows: &[TransactionQueryRes]) -> Result<Vec<Column>, Box<
                 .map(serde_json::to_string)
                 .transpose()
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<Option<String>>, _>>()?;
     push(&mut cols, str_col("authorization_list", authorization_list));
     Ok(cols)
 }
@@ -517,7 +536,7 @@ fn log_columns(rows: &[LogQueryRes]) -> Result<Vec<Column>, Box<dyn Error>> {
         &mut cols,
         str_col(
             "address",
-            col(rows, |r| r.address.as_ref().map(|a| format!("{a:?}"))),
+            col(rows, |r| r.address.as_ref().map(|a| format!("{a:#x}"))),
         ),
     );
     push(
@@ -796,6 +815,46 @@ mod test {
         }];
         let cols = account_columns(&rows).unwrap();
         assert_eq!(column_types(&cols)["balance"], DataType::Decimal128(38, 0));
+    }
+
+    #[test]
+    fn parquet_empty_result_writes_readable_full_schema() {
+        use arrow::record_batch::RecordBatchReader;
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+        // An empty result must produce a valid, readable Parquet file with the
+        // entity's full schema and zero rows — not a malformed zero-column file.
+        let empty = ExpressionResult::Log(Vec::<LogQueryRes>::new());
+        let bytes = serialize_parquet(&empty).unwrap();
+        assert!(!bytes.is_empty());
+
+        let path = std::env::temp_dir().join(format!("eql_empty_{}.parquet", std::process::id()));
+        std::fs::write(&path, &bytes).unwrap();
+        let file = std::fs::File::open(&path).unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let schema = reader.schema();
+        for name in ["chain", "address", "topic0", "block_number", "removed"] {
+            assert!(
+                schema.field_with_name(name).is_ok(),
+                "missing column {name}"
+            );
+        }
+        let rows: usize = reader.map(|b| b.unwrap().num_rows()).sum();
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(rows, 0);
+    }
+
+    #[test]
+    fn parquet_all_null_rows_still_write_a_valid_file() {
+        // Rows present but every selected field null (e.g. only contract-creation
+        // txs when `to_address` was selected): all columns are skipped, so the
+        // full-schema fallback keeps the file valid.
+        let result = ExpressionResult::Transaction(vec![TransactionQueryRes::default(); 3]);
+        let bytes = serialize_parquet(&result).unwrap();
+        assert!(!bytes.is_empty());
     }
 
     #[test]

--- a/crates/core/src/common/serializer.rs
+++ b/crates/core/src/common/serializer.rs
@@ -4,11 +4,14 @@ use std::sync::Arc;
 
 use super::{
     dump::{Dump, DumpFormat},
-    query_result::ExpressionResult,
+    query_result::{
+        AccountQueryRes, BlockQueryRes, ExpressionResult, LogQueryRes, TransactionQueryRes,
+    },
 };
-use arrow::array::{ArrayRef, StringArray};
+use alloy::primitives::U256;
+use arrow::array::{ArrayRef, BooleanArray, Decimal128Array, StringArray, UInt64Array, UInt8Array};
 use arrow::datatypes::{DataType, Field, Schema};
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use parquet::arrow::ArrowWriter;
 use serde::Serialize;
 
@@ -110,19 +113,30 @@ fn serialize_csv<T: Serialize>(results: &Vec<T>) -> Result<String, Box<dyn Error
 }
 
 fn serialize_parquet(result: &ExpressionResult) -> Result<Vec<u8>, Box<dyn Error>> {
-    let (schema, data) = match result {
-        ExpressionResult::Account(accounts) => create_parquet_schema_and_data(accounts)?,
-        ExpressionResult::Block(blocks) => create_parquet_schema_and_data(blocks)?,
-        ExpressionResult::Transaction(transactions) => {
-            create_parquet_schema_and_data(transactions)?
-        }
-        ExpressionResult::Log(logs) => create_parquet_schema_and_data(logs)?,
+    let (columns, num_rows) = match result {
+        ExpressionResult::Account(rows) => (account_columns(rows)?, rows.len()),
+        ExpressionResult::Block(rows) => (block_columns(rows)?, rows.len()),
+        ExpressionResult::Transaction(rows) => (transaction_columns(rows)?, rows.len()),
+        ExpressionResult::Log(rows) => (log_columns(rows)?, rows.len()),
     };
 
-    let batch = RecordBatch::try_new(Arc::new(schema), data)?;
+    let (fields, arrays): (Vec<Field>, Vec<ArrayRef>) = columns.into_iter().unzip();
+    let schema = Arc::new(Schema::new(fields));
+
+    // With no columns (an empty result, or a query whose selected fields are
+    // all null) Arrow can't infer the row count from the arrays, so pass it.
+    let batch = if arrays.is_empty() {
+        RecordBatch::try_new_with_options(
+            schema.clone(),
+            arrays,
+            &RecordBatchOptions::new().with_row_count(Some(num_rows)),
+        )?
+    } else {
+        RecordBatch::try_new(schema.clone(), arrays)?
+    };
 
     let mut buf = Vec::new();
-    let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), None)?;
+    let mut writer = ArrowWriter::try_new(&mut buf, schema, None)?;
 
     writer.write(&batch)?;
     writer.close()?;
@@ -130,46 +144,471 @@ fn serialize_parquet(result: &ExpressionResult) -> Result<Vec<u8>, Box<dyn Error
     Ok(buf)
 }
 
-fn create_parquet_schema_and_data<T: Serialize>(
-    items: &[T],
-) -> Result<(Schema, Vec<ArrayRef>), Box<dyn Error>> {
-    let mut fields = Vec::new();
-    let mut data = Vec::new();
+// --- Typed Parquet columns ---------------------------------------------------
+//
+// Each entity's row struct (see `query_result.rs`) maps onto Arrow columns with
+// a proper type per field, read straight off the struct rather than through
+// `serde_json`. A column is emitted only when at least one row sets the field:
+// unselected fields don't produce all-null columns, and the schema no longer
+// depends on which fields happen to be present in the first row.
 
-    if let Some(first_item) = items.first() {
-        let value = serde_json::to_value(first_item)?;
-        if let serde_json::Value::Object(map) = value {
-            for (key, _) in map {
-                let field = Field::new(&key, DataType::Utf8, true);
-                fields.push(field);
+type Column = (Field, ArrayRef);
 
-                let column_data: Vec<Option<String>> = items
-                    .iter()
-                    .map(|item| {
-                        let item_value = serde_json::to_value(item).unwrap();
-                        if let serde_json::Value::Object(item_map) = item_value {
-                            item_map.get(&key).and_then(|v| Some(v.to_string()))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
+fn all_none<T>(vals: &[Option<T>]) -> bool {
+    vals.iter().all(Option::is_none)
+}
 
-                data.push(Arc::new(StringArray::from(column_data)) as ArrayRef);
-            }
-        }
+fn col<R, T>(rows: &[R], f: impl Fn(&R) -> Option<T>) -> Vec<Option<T>> {
+    rows.iter().map(f).collect()
+}
+
+fn push(cols: &mut Vec<Column>, column: Option<Column>) {
+    if let Some(column) = column {
+        cols.push(column);
     }
+}
 
-    let schema = Schema::new(fields);
-    Ok((schema, data))
+fn u64_col(name: &str, vals: Vec<Option<u64>>) -> Option<Column> {
+    if all_none(&vals) {
+        return None;
+    }
+    Some((
+        Field::new(name, DataType::UInt64, true),
+        Arc::new(UInt64Array::from(vals)) as ArrayRef,
+    ))
+}
+
+fn u8_col(name: &str, vals: Vec<Option<u8>>) -> Option<Column> {
+    if all_none(&vals) {
+        return None;
+    }
+    Some((
+        Field::new(name, DataType::UInt8, true),
+        Arc::new(UInt8Array::from(vals)) as ArrayRef,
+    ))
+}
+
+fn bool_col(name: &str, vals: Vec<Option<bool>>) -> Option<Column> {
+    if all_none(&vals) {
+        return None;
+    }
+    Some((
+        Field::new(name, DataType::Boolean, true),
+        Arc::new(BooleanArray::from(vals)) as ArrayRef,
+    ))
+}
+
+fn str_col(name: &str, vals: Vec<Option<String>>) -> Option<Column> {
+    if all_none(&vals) {
+        return None;
+    }
+    Some((
+        Field::new(name, DataType::Utf8, true),
+        Arc::new(StringArray::from(vals)) as ArrayRef,
+    ))
+}
+
+/// Quantity `U256` fields (balances, values, sizes, difficulty) as
+/// `Decimal128(38, 0)`. 38 decimal digits hold every real chain quantity (the
+/// largest conceivable native balance is far below 10^38 wei), and DuckDB and
+/// Polars — whose `DECIMAL` maxes out at precision 38 — read it back exactly,
+/// whereas a wider `Decimal256` would be downcast to a lossy `double`. A column
+/// carrying a value that doesn't fit — only a synthetic one, e.g. a `U256::MAX`
+/// test-net balance — falls back to lossless decimal strings rather than being
+/// truncated. Full-range signature fields (`r`/`s`) are always decimal strings.
+fn u256_col(name: &str, vals: Vec<Option<U256>>) -> Result<Option<Column>, Box<dyn Error>> {
+    if all_none(&vals) {
+        return Ok(None);
+    }
+    // 10^38 is Decimal128(38, 0)'s exclusive upper bound.
+    let limit = U256::from(10).pow(U256::from(38));
+    if vals.iter().flatten().all(|v| *v < limit) {
+        let values: Vec<Option<i128>> = vals
+            .into_iter()
+            .map(|v| v.map(u256_to_i128).transpose())
+            .collect::<Result<_, _>>()?;
+        let array = Decimal128Array::from(values).with_precision_and_scale(38, 0)?;
+        Ok(Some((
+            Field::new(name, DataType::Decimal128(38, 0), true),
+            Arc::new(array) as ArrayRef,
+        )))
+    } else {
+        Ok(str_col(name, decimal_strings(vals)))
+    }
+}
+
+/// A `U256` known to be below 10^38 as an `i128` for `Decimal128`. The
+/// conversions can't fail given that bound, but are checked rather than
+/// wrapping so a caller that ignored the bound gets an error, not a bad value.
+fn u256_to_i128(value: U256) -> Result<i128, Box<dyn Error>> {
+    Ok(i128::try_from(u128::try_from(value)?)?)
+}
+
+/// `u128` gas fields as `Decimal128(38, 0)` — 38 digits covers every realistic
+/// gas value. A value at/above 10^38 (never a real gas price) can't fit and
+/// makes the column fall back to lossless decimal strings, same as `u256_col`.
+fn u128_col(name: &str, vals: Vec<Option<u128>>) -> Result<Option<Column>, Box<dyn Error>> {
+    if all_none(&vals) {
+        return Ok(None);
+    }
+    let limit = 10u128.pow(38);
+    if vals.iter().flatten().all(|v| *v < limit) {
+        let values: Vec<Option<i128>> = vals.into_iter().map(|v| v.map(|u| u as i128)).collect();
+        let array = Decimal128Array::from(values).with_precision_and_scale(38, 0)?;
+        Ok(Some((
+            Field::new(name, DataType::Decimal128(38, 0), true),
+            Arc::new(array) as ArrayRef,
+        )))
+    } else {
+        Ok(str_col(
+            name,
+            vals.into_iter().map(|v| v.map(|u| u.to_string())).collect(),
+        ))
+    }
+}
+
+/// Render each present `U256` as its decimal string (for the fallback column).
+fn decimal_strings(vals: Vec<Option<U256>>) -> Vec<Option<String>> {
+    vals.into_iter().map(|v| v.map(|u| u.to_string())).collect()
+}
+
+fn account_columns(rows: &[AccountQueryRes]) -> Result<Vec<Column>, Box<dyn Error>> {
+    let mut cols = Vec::new();
+    push(
+        &mut cols,
+        str_col(
+            "chain",
+            col(rows, |r| r.chain.as_ref().map(|c| c.to_string())),
+        ),
+    );
+    push(&mut cols, u64_col("nonce", col(rows, |r| r.nonce)));
+    push(&mut cols, u256_col("balance", col(rows, |r| r.balance))?);
+    push(
+        &mut cols,
+        str_col(
+            "address",
+            col(rows, |r| r.address.as_ref().map(|a| format!("{a:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "code",
+            col(rows, |r| r.code.as_ref().map(|c| format!("{c:?}"))),
+        ),
+    );
+    Ok(cols)
+}
+
+fn block_columns(rows: &[BlockQueryRes]) -> Result<Vec<Column>, Box<dyn Error>> {
+    let mut cols = Vec::new();
+    push(
+        &mut cols,
+        str_col(
+            "chain",
+            col(rows, |r| r.chain.as_ref().map(|c| c.to_string())),
+        ),
+    );
+    push(&mut cols, u64_col("number", col(rows, |r| r.number)));
+    push(&mut cols, u64_col("timestamp", col(rows, |r| r.timestamp)));
+    push(
+        &mut cols,
+        str_col(
+            "hash",
+            col(rows, |r| r.hash.as_ref().map(|h| format!("{h:?}"))),
+        ),
+    );
+    push(&mut cols, u256_col("size", col(rows, |r| r.size))?);
+    push(
+        &mut cols,
+        str_col(
+            "parent_hash",
+            col(rows, |r| r.parent_hash.as_ref().map(|h| format!("{h:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "state_root",
+            col(rows, |r| r.state_root.as_ref().map(|h| format!("{h:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "transactions_root",
+            col(rows, |r| {
+                r.transactions_root.as_ref().map(|h| format!("{h:?}"))
+            }),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "receipts_root",
+            col(rows, |r| r.receipts_root.as_ref().map(|h| format!("{h:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "logs_bloom",
+            col(rows, |r| r.logs_bloom.as_ref().map(|b| format!("{b:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "extra_data",
+            col(rows, |r| r.extra_data.as_ref().map(|b| format!("{b:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "mix_hash",
+            col(rows, |r| r.mix_hash.as_ref().map(|h| format!("{h:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        u256_col("total_difficulty", col(rows, |r| r.total_difficulty))?,
+    );
+    push(
+        &mut cols,
+        u64_col("base_fee_per_gas", col(rows, |r| r.base_fee_per_gas)),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "withdrawals_root",
+            col(rows, |r| {
+                r.withdrawals_root.as_ref().map(|h| format!("{h:?}"))
+            }),
+        ),
+    );
+    push(
+        &mut cols,
+        u64_col("blob_gas_used", col(rows, |r| r.blob_gas_used)),
+    );
+    push(
+        &mut cols,
+        u64_col("excess_blob_gas", col(rows, |r| r.excess_blob_gas)),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "parent_beacon_block_root",
+            col(rows, |r| {
+                r.parent_beacon_block_root
+                    .as_ref()
+                    .map(|h| format!("{h:?}"))
+            }),
+        ),
+    );
+    Ok(cols)
+}
+
+fn transaction_columns(rows: &[TransactionQueryRes]) -> Result<Vec<Column>, Box<dyn Error>> {
+    let mut cols = Vec::new();
+    push(
+        &mut cols,
+        str_col(
+            "chain",
+            col(rows, |r| r.chain.as_ref().map(|c| c.to_string())),
+        ),
+    );
+    push(&mut cols, u8_col("type", col(rows, |r| r.r#type)));
+    push(
+        &mut cols,
+        str_col(
+            "hash",
+            col(rows, |r| r.hash.as_ref().map(|h| format!("{h:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        u64_col("block_number", col(rows, |r| r.block_number)),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "from_address",
+            col(rows, |r| r.from_address.as_ref().map(|a| format!("{a:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "to_address",
+            col(rows, |r| r.to_address.as_ref().map(|a| format!("{a:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "data",
+            col(rows, |r| r.data.as_ref().map(|d| format!("{d:?}"))),
+        ),
+    );
+    push(&mut cols, u256_col("value", col(rows, |r| r.value))?);
+    push(
+        &mut cols,
+        u128_col("gas_price", col(rows, |r| r.gas_price))?,
+    );
+    push(&mut cols, u64_col("gas_limit", col(rows, |r| r.gas_limit)));
+    push(
+        &mut cols,
+        u128_col("effective_gas_price", col(rows, |r| r.effective_gas_price))?,
+    );
+    push(&mut cols, bool_col("status", col(rows, |r| r.status)));
+    push(&mut cols, u64_col("chain_id", col(rows, |r| r.chain_id)));
+    push(&mut cols, bool_col("v", col(rows, |r| r.v)));
+    push(
+        &mut cols,
+        str_col("r", col(rows, |r| r.r.as_ref().map(|x| x.to_string()))),
+    );
+    push(
+        &mut cols,
+        str_col("s", col(rows, |r| r.s.as_ref().map(|x| x.to_string()))),
+    );
+    push(
+        &mut cols,
+        u128_col(
+            "max_fee_per_blob_gas",
+            col(rows, |r| r.max_fee_per_blob_gas),
+        )?,
+    );
+    push(
+        &mut cols,
+        u128_col("max_fee_per_gas", col(rows, |r| r.max_fee_per_gas))?,
+    );
+    push(
+        &mut cols,
+        u128_col(
+            "max_priority_fee_per_gas",
+            col(rows, |r| r.max_priority_fee_per_gas),
+        )?,
+    );
+    push(&mut cols, bool_col("y_parity", col(rows, |r| r.y_parity)));
+    push(
+        &mut cols,
+        str_col(
+            "authorization_list",
+            col(rows, |r| {
+                r.authorization_list
+                    .as_ref()
+                    .map(|a| serde_json::to_string(a).unwrap_or_default())
+            }),
+        ),
+    );
+    Ok(cols)
+}
+
+fn log_columns(rows: &[LogQueryRes]) -> Result<Vec<Column>, Box<dyn Error>> {
+    let mut cols = Vec::new();
+    push(
+        &mut cols,
+        str_col(
+            "chain",
+            col(rows, |r| r.chain.as_ref().map(|c| c.to_string())),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "address",
+            col(rows, |r| r.address.as_ref().map(|a| format!("{a:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "topic0",
+            col(rows, |r| r.topic0.as_ref().map(|t| format!("{t:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "topic1",
+            col(rows, |r| r.topic1.as_ref().map(|t| format!("{t:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "topic2",
+            col(rows, |r| r.topic2.as_ref().map(|t| format!("{t:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "topic3",
+            col(rows, |r| r.topic3.as_ref().map(|t| format!("{t:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "data",
+            col(rows, |r| r.data.as_ref().map(|d| format!("{d:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "block_hash",
+            col(rows, |r| r.block_hash.as_ref().map(|h| format!("{h:?}"))),
+        ),
+    );
+    push(
+        &mut cols,
+        u64_col("block_number", col(rows, |r| r.block_number)),
+    );
+    push(
+        &mut cols,
+        u64_col("block_timestamp", col(rows, |r| r.block_timestamp)),
+    );
+    push(
+        &mut cols,
+        str_col(
+            "transaction_hash",
+            col(rows, |r| {
+                r.transaction_hash.as_ref().map(|h| format!("{h:?}"))
+            }),
+        ),
+    );
+    push(
+        &mut cols,
+        u64_col("transaction_index", col(rows, |r| r.transaction_index)),
+    );
+    push(&mut cols, u64_col("log_index", col(rows, |r| r.log_index)));
+    push(&mut cols, bool_col("removed", col(rows, |r| r.removed)));
+    Ok(cols)
 }
 
 #[cfg(test)]
 mod test {
-    use super::{apply_aliases, serialize_csv, serialize_json, serialize_parquet};
-    use crate::common::query_result::{AccountQueryRes, ExpressionResult};
-    use alloy::primitives::U256;
+    use super::{
+        account_columns, apply_aliases, block_columns, log_columns, serialize_csv, serialize_json,
+        serialize_parquet, transaction_columns, Column,
+    };
+    use crate::common::query_result::{
+        AccountQueryRes, BlockQueryRes, ExpressionResult, LogQueryRes, TransactionQueryRes,
+    };
+    use alloy::primitives::{B256, U256};
+    use arrow::array::{StringArray, UInt64Array};
+    use arrow::datatypes::DataType;
+    use std::collections::HashMap;
     use std::str::FromStr;
+
+    fn column_types(cols: &[Column]) -> HashMap<String, DataType> {
+        cols.iter()
+            .map(|(f, _)| (f.name().clone(), f.data_type().clone()))
+            .collect()
+    }
 
     #[test]
     fn test_serialize_json() {
@@ -224,6 +663,140 @@ mod test {
         // Since Parquet is a binary format, we can't easily assert its content.
         // Instead, we'll just check that we get a non-empty result.
         assert!(!content.is_empty());
+    }
+
+    #[test]
+    fn parquet_account_columns_are_typed() {
+        let rows = vec![AccountQueryRes {
+            nonce: Some(3),
+            balance: Some(U256::from(100u64)),
+            address: Some(alloy::primitives::Address::ZERO),
+            ..Default::default()
+        }];
+        let cols = account_columns(&rows).unwrap();
+        let types = column_types(&cols);
+
+        assert_eq!(types["nonce"], DataType::UInt64);
+        assert_eq!(types["balance"], DataType::Decimal128(38, 0));
+        assert_eq!(types["address"], DataType::Utf8);
+        // `chain`/`code` were never set, so they aren't columns.
+        assert!(!types.contains_key("chain"));
+        assert!(!types.contains_key("code"));
+    }
+
+    #[test]
+    fn parquet_block_columns_are_typed() {
+        let rows = vec![BlockQueryRes {
+            number: Some(21_000_000),
+            timestamp: Some(1_700_000_000),
+            size: Some(U256::from(1234u64)),
+            hash: Some(B256::ZERO),
+            base_fee_per_gas: Some(7),
+            ..Default::default()
+        }];
+        let cols = block_columns(&rows).unwrap();
+        let types = column_types(&cols);
+
+        assert_eq!(types["number"], DataType::UInt64);
+        assert_eq!(types["timestamp"], DataType::UInt64);
+        assert_eq!(types["size"], DataType::Decimal128(38, 0));
+        assert_eq!(types["hash"], DataType::Utf8);
+        // An unset field never becomes a column.
+        assert!(!types.contains_key("parent_hash"));
+
+        let number = cols
+            .iter()
+            .find(|(f, _)| f.name() == "number")
+            .unwrap()
+            .1
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        assert_eq!(number.value(0), 21_000_000);
+    }
+
+    #[test]
+    fn parquet_transaction_columns_are_typed() {
+        let rows = vec![TransactionQueryRes {
+            status: Some(true),
+            gas_price: Some(1_000_000_000),
+            value: Some(U256::from(42u64)),
+            r: Some(U256::from(7u64)),
+            authorization_list: Some(vec![]),
+            ..Default::default()
+        }];
+        let cols = transaction_columns(&rows).unwrap();
+        let types = column_types(&cols);
+
+        assert_eq!(types["status"], DataType::Boolean);
+        assert_eq!(types["gas_price"], DataType::Decimal128(38, 0));
+        assert_eq!(types["value"], DataType::Decimal128(38, 0));
+        // Full-range signature components stay as decimal strings.
+        assert_eq!(types["r"], DataType::Utf8);
+        assert_eq!(types["authorization_list"], DataType::Utf8);
+    }
+
+    #[test]
+    fn parquet_log_columns_are_typed() {
+        let rows = vec![LogQueryRes {
+            removed: Some(false),
+            topic0: Some(B256::ZERO),
+            block_number: Some(123),
+            log_index: Some(4),
+            ..Default::default()
+        }];
+        let cols = log_columns(&rows).unwrap();
+        let types = column_types(&cols);
+
+        assert_eq!(types["removed"], DataType::Boolean);
+        assert_eq!(types["topic0"], DataType::Utf8);
+        assert_eq!(types["block_number"], DataType::UInt64);
+        assert_eq!(types["log_index"], DataType::UInt64);
+    }
+
+    #[test]
+    fn parquet_u256_beyond_decimal128_falls_back_to_string() {
+        // A value that overflows Decimal128(38, 0) — here U256::MAX, the kind
+        // of synthetic balance a dev/test net genesis sets — must not corrupt
+        // or fail the dump. The whole column degrades to lossless decimal text.
+        let huge = U256::MAX;
+        let rows = vec![
+            AccountQueryRes {
+                balance: Some(U256::from(100u64)),
+                ..Default::default()
+            },
+            AccountQueryRes {
+                balance: Some(huge),
+                ..Default::default()
+            },
+        ];
+        let cols = account_columns(&rows).unwrap();
+        let types = column_types(&cols);
+        assert_eq!(types["balance"], DataType::Utf8);
+
+        let balance = cols
+            .iter()
+            .find(|(f, _)| f.name() == "balance")
+            .unwrap()
+            .1
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(balance.value(0), "100");
+        assert_eq!(balance.value(1), huge.to_string());
+    }
+
+    #[test]
+    fn parquet_u256_within_decimal128_stays_numeric() {
+        // A large-but-representable balance (10^30 wei ≈ 10^12 ETH, far above
+        // any real holding yet well under 10^38) stays a Decimal128 column.
+        let big = U256::from(10u64).pow(U256::from(30u64));
+        let rows = vec![AccountQueryRes {
+            balance: Some(big),
+            ..Default::default()
+        }];
+        let cols = account_columns(&rows).unwrap();
+        assert_eq!(column_types(&cols)["balance"], DataType::Decimal128(38, 0));
     }
 
     #[test]

--- a/crates/core/src/interpreter/frontend/sql/prelex.rs
+++ b/crates/core/src/interpreter/frontend/sql/prelex.rs
@@ -30,7 +30,6 @@ fn tokenize(input: &str) -> Vec<Tok> {
                 i += 1;
             }
             toks.push(Tok::Quoted(chars[start..i].iter().collect()));
-        }
         } else if c == '-' && chars.get(i + 1) == Some(&'-') {
             let start = i;
             while i < chars.len() && chars[i] != '\n' {


### PR DESCRIPTION
## What

The Parquet exporter wrote **every column as a string**. It ran each row
through `serde_json`, forced every field to `Utf8`, and stringified the
value — so block numbers, timestamps, gas, nonces, indices, and booleans
all came out as text. It also read the schema from the first row only, so
a field that was `None` in row 0 vanished from every row.

This builds typed Arrow columns straight from the `*QueryRes` structs:

| Field kind | Arrow type |
|---|---|
| `u64` / `u8` (numbers, timestamps, gas, nonces, indices) | `UInt64` / `UInt8` |
| `bool` (status, v, y_parity, removed) | `Boolean` |
| hashes, addresses, `Bytes`, `Bloom` | hex string (`0x…`) |
| quantity `U256` + `u128` gas | `Decimal128(38,0)` |
| full-range `U256` `r` / `s` | decimal string |
| `Chain` | its name |
| `authorization_list` | JSON string |

A column is emitted only when some row sets the field, which also fixes
the first-row-only schema bug. JSON and CSV export are unchanged.

## Why Decimal128, not Decimal256

`Decimal128(38,0)` reads back **exactly** in DuckDB and Polars, whose
`DECIMAL` maxes out at precision 38; a wider `Decimal256` is silently
downcast to a lossy `double` on read. 38 digits hold every real economic
value (the largest native balance is far below 10^38 wei). A value that
does not fit — only a synthetic one, e.g. a `U256::MAX` test-net balance —
makes that column **fall back to lossless decimal strings** rather than
truncate or fail. (ERC20/token amounts never reach these columns; they
live in tx `data` / log `data` as hex strings.)

## Commits

- `fix(sql): remove stray brace breaking prelex compilation` — a duplicate
  `}` in the SQL prelexer's `tokenize` meant `eql_core` did not compile at
  all. Kept as its own commit since it is unrelated to the export work.
- `feat(export): write typed Parquet columns instead of all-varchar`

## Testing

- `cargo test -p eql_core serializer` — 13 pass, including tests that a
  `U256::MAX` balance falls back to a lossless string column and a 10^30
  balance stays `Decimal128`.
- End to end: dumped Ethereum logs and an account balance to Parquet;
  DuckDB reads `block_number`/`log_index` as `ubigint`, `removed` as
  `boolean`, byte fields as `varchar`, and the balance as exact
  `DECIMAL(38,0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parquet exports now preserve appropriate column data types, including numeric types for supported large integers.
  * Large integer values that exceed numeric limits are exported losslessly as text.
  * Fields with no values across the exported data are omitted from the Parquet schema.

* **Bug Fixes**
  * Fixed SQL tokenization so line comments are correctly recognized after quoted strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->